### PR TITLE
Добавил каналы в типы чатов

### DIFF
--- a/maxapi/enums/chat_type.py
+++ b/maxapi/enums/chat_type.py
@@ -11,3 +11,4 @@ class ChatType(str, Enum):
     
     DIALOG = 'dialog'
     CHAT = 'chat'
+    CHANNEL = 'channel'


### PR DESCRIPTION
Теперь pydantic не ругается при отправке сообщений в каналы.

Было:
`Validation Error: 1 validation error for Chat
type
  Input should be 'dialog' or 'chat' [type=enum, input_value='channel', input_type=str]
    For further information visit https://errors.pydantic.dev/2.12/v/enum`