### PR TITLE
Исправлена ошибка при отправке вложения типа file с использованием класса Attachment

### DIFF
--- a/maxapi/methods/edit_message.py
+++ b/maxapi/methods/edit_message.py
@@ -11,6 +11,7 @@ from ..exceptions.max import MaxApiError
 from ..loggers import logger_bot
 from ..types.attachments import Attachments
 from ..types.attachments.attachment import Attachment
+from ..types.attachments.upload import AttachmentUpload
 from ..types.input_media import InputMedia, InputMediaBuffer
 from ..types.message import NewMessageLink
 from ..utils.message import process_input_media
@@ -97,6 +98,10 @@ class EditMessage(BaseConnection):
                         base_connection=self, bot=bot, att=att
                     )
                     json["attachments"].append(input_media.model_dump())
+                elif isinstance(att, Attachment) and isinstance(
+                    att.payload, AttachmentUpload
+                ):
+                    json["attachments"].append(att.payload.model_dump())
                 else:
                     json["attachments"].append(att.model_dump())
 

--- a/maxapi/methods/send_message.py
+++ b/maxapi/methods/send_message.py
@@ -9,6 +9,7 @@ from ..exceptions.max import MaxApiError
 from ..loggers import logger_bot
 from ..types.attachments import Attachments
 from ..types.attachments.attachment import Attachment
+from ..types.attachments.upload import AttachmentUpload
 from ..types.input_media import InputMedia, InputMediaBuffer
 from ..types.message import NewMessageLink
 from ..utils.message import process_input_media
@@ -101,6 +102,10 @@ class SendMessage(BaseConnection):
                         base_connection=self, bot=bot, att=att
                     )
                     json["attachments"].append(input_media.model_dump())
+                elif isinstance(att, Attachment) and isinstance(
+                    att.payload, AttachmentUpload
+                ):
+                    json["attachments"].append(att.payload.model_dump())
                 else:
                     json["attachments"].append(att.model_dump())
 


### PR DESCRIPTION
При запуске следующего кода для повторной отправки файла, используя токен, была получена ошибка

```python
token = "f9LHodD0cOKrwR1wPI46yDNaG_IJeHF1xOAOdS337FBBnnZImbE..."
attachment = Attachment(
    type=AttachmentType.FILE,
    payload=AttachmentUpload(
    type=UploadType.FILE,
        payload=AttachmentPayload(token=token),
    ),
)
await bot.send_message(
    text="Проверка", user_id=USER_ID, attachments=[attachment]
)
```

Текст ошибки

```
maxapi.exceptions.max.MaxApiError: Ошибка от API: self.code=400 self.raw={'code': 'proto.payload', 'message': 'Missing `token` in video attachment'}
```

Было выяснено, что в Max API отправляется JSON следующего вида.

```json
{"attachments": [{"type": "file", "payload": {"type": "file", "payload": {"token": "f9LHodD0cOKrwR1wPI46yDNaG_IJeHF1xOAOdS337FBBnnZImbE..."}}}], "text": "Проверка", "format": "html"}
```

Но Max API ожидает другой JSON

```json
{"attachments": [{"type": "file", "payload": {"token": "f9LHodD0cOKrwR1wPI46yDNaG_IJeHF1xOAOdS337FBBnnZImbE..."}}], "text": "Проверка", "format": "html"}
```

Для исправления этой ошибки была исправлена обработка поля attachments в  SendMessage.fetch и EditMessage.fetch

```python
            for att in self.attachments:
                if isinstance(att, InputMedia) or isinstance(
                    att, InputMediaBuffer
                ):
                    HAS_INPUT_MEDIA = True

                    input_media = await process_input_media(
                        base_connection=self, bot=bot, att=att
                    )
                    json["attachments"].append(input_media.model_dump())
+               elif isinstance(att, Attachment) and isinstance(
+                   att.payload, AttachmentUpload
+               ):
+                   json["attachments"].append(att.payload.model_dump())
                else:
                    json["attachments"].append(att.model_dump())
```