### PR TITLE
Добавление поддержки сравнения State со строкой для совместимости с хранилищем Redis

### DIFF
--- a/maxapi/context/state_machine.py
+++ b/maxapi/context/state_machine.py
@@ -17,6 +17,15 @@ class State:
     def __str__(self):
         return self.name
 
+    def __eq__(self, value: object, /) -> bool:
+        if isinstance(value, State):
+            return self.name == value.name
+        if isinstance(value, str):
+            return self.name == value
+        raise NotImplementedError(
+            f"Сравнение `State` с типом {type(value)} невозможно"
+        )
+
 
 class StatesGroup:
     """


### PR DESCRIPTION
С другом пытаемся добавить хранилище контекста в Redis, однако столкнулись с проблемой поиска обработчика, если `current_state` представлен в виде строки
В текущей реализации логика поиска обработчиков по состоянию некорректно отрабатывает при использовании состояния в виде строки вместо экземпляров класса State. Это происходит из-за того, что сравнение `State == str` всегда возвращает False, что ломает проверку в методе `Dispatcher._check_handler_match`:
```py
if handler.states:
    if current_state not in handler.states:
        return False
```

При реализации хранилища контекста в Redis возникла необходимость использовать строковые ключи. Для решения проблемы перегрузил метод сравнения у класса `State`:

```py
def __eq__(self, value: object, /) -> bool:
    if isinstance(value, State):
        return self.name == value.name
    if isinstance(value, str):
        return self.name == value
    raise NotImplementedError(
        f"Сравнение `State` с типом {type(value)} невозможно"
    )
```
