### PR TITLE
fix: исправление багов, типизация, рефакторинг

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,2 @@
-include LICENSE.md
+include LICENSE
 include README.md

--- a/maxapi/bot.py
+++ b/maxapi/bot.py
@@ -538,20 +538,20 @@ class Bot(BaseConnection):
 
         return await GetChatByLink(bot=self, link=link).fetch()
 
-    async def get_chat_by_id(self, id: int) -> Chat:
+    async def get_chat_by_id(self, chat_id: int) -> Chat:
         """
         Получает чат по ID.
 
         https://dev.max.ru/docs-api/methods/GET/chats/-chatId-
 
         Args:
-            id (int): ID чата.
+            chat_id (int): ID чата.
 
         Returns:
             Chat: Объект чата.
         """
 
-        return await GetChatById(bot=self, id=id).fetch()
+        return await GetChatById(bot=self, id=chat_id).fetch()
 
     async def edit_chat(
         self,

--- a/maxapi/context/state_machine.py
+++ b/maxapi/context/state_machine.py
@@ -5,17 +5,21 @@ class State:
     """
     Представляет отдельное состояние в FSM-группе.
 
-    При использовании внутри StatesGroup, автоматически присваивает уникальное имя в формате 'ИмяКласса:имя_поля'.
+    При использовании внутри StatesGroup, автоматически присваивает
+    уникальное имя в формате 'ИмяКласса:имя_поля'.
     """
 
-    def __init__(self):
-        self.name = None
+    def __init__(self) -> None:
+        self.name: str | None = None
 
-    def __set_name__(self, owner: type, attr_name: str):
+    def __set_name__(self, owner: type, attr_name: str) -> None:
         self.name = f"{owner.__name__}:{attr_name}"
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.name or ""
+
+    def __repr__(self) -> str:
+        return f"State(name={self.name!r})"
 
     def __eq__(self, value: object, /) -> bool:
         if value is None:
@@ -27,6 +31,9 @@ class State:
         raise NotImplementedError(
             f"Сравнение `State` с типом {type(value)} невозможно"
         )
+
+    def __hash__(self) -> int:
+        return hash(self.name)
 
 
 class StatesGroup:

--- a/maxapi/exceptions/max.py
+++ b/maxapi/exceptions/max.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from typing import Any
 
 
 class InvalidToken(Exception): ...
@@ -15,8 +16,15 @@ class MaxIconParamsException(Exception): ...
 
 @dataclass(slots=True)
 class MaxApiError(Exception):
+    """Ошибка, возвращённая API MAX.
+
+    Attributes:
+        code: HTTP-код ответа.
+        raw: Сырой ответ от API (обычно dict из JSON).
+    """
+
     code: int
-    raw: str
+    raw: Any
 
     def __str__(self) -> str:
         return f"Ошибка от API: {self.code=} {self.raw=}"

--- a/maxapi/filters/command.py
+++ b/maxapi/filters/command.py
@@ -147,9 +147,7 @@ class Command(BaseFilter):
             return False
 
         if not self.check_case:
-            if parsed_command.lower() in [
-                commands.lower() for commands in self.commands
-            ]:
+            if parsed_command.lower() in self.commands:
                 return {"args": args}
             else:
                 return False

--- a/maxapi/methods/edit_message.py
+++ b/maxapi/methods/edit_message.py
@@ -85,14 +85,12 @@ class EditMessage(BaseConnection):
         if self.text is not None:
             json["text"] = self.text
 
-        HAS_INPUT_MEDIA = False
+        has_input_media = False
 
         if self.attachments:
             for att in self.attachments:
-                if isinstance(att, InputMedia) or isinstance(
-                    att, InputMediaBuffer
-                ):
-                    HAS_INPUT_MEDIA = True
+                if isinstance(att, (InputMedia, InputMediaBuffer)):
+                    has_input_media = True
 
                     input_media = await process_input_media(
                         base_connection=self, bot=bot, att=att
@@ -112,7 +110,7 @@ class EditMessage(BaseConnection):
         if self.parse_mode is not None:
             json["format"] = self.parse_mode.value
 
-        if HAS_INPUT_MEDIA and self.sleep_after_input_media:
+        if has_input_media and self.sleep_after_input_media:
             await asyncio.sleep(bot.after_input_media_delay)
 
         response = None
@@ -129,7 +127,10 @@ class EditMessage(BaseConnection):
             except MaxApiError as e:
                 if "attachment.not.ready" in e.raw:
                     logger_bot.info(
-                        f"Ошибка при отправке загруженного медиа, попытка {attempt + 1}, жду {self.RETRY_DELAY} секунды"
+                        "Ошибка при отправке загруженного медиа, "
+                        "попытка %d, жду %d секунды",
+                        attempt + 1,
+                        self.RETRY_DELAY,
                     )
                     await asyncio.sleep(self.RETRY_DELAY)
                     continue

--- a/maxapi/methods/send_message.py
+++ b/maxapi/methods/send_message.py
@@ -91,12 +91,12 @@ class SendMessage(BaseConnection):
 
         json["text"] = self.text
 
-        HAS_INPUT_MEDIA = False
+        has_input_media = False
 
         if self.attachments:
             for att in self.attachments:
                 if isinstance(att, (InputMedia, InputMediaBuffer)):
-                    HAS_INPUT_MEDIA = True
+                    has_input_media = True
 
                     input_media = await process_input_media(
                         base_connection=self, bot=bot, att=att
@@ -112,16 +112,16 @@ class SendMessage(BaseConnection):
         if self.link is not None:
             json["link"] = self.link.model_dump()
 
-        if self.notify:
+        if self.notify is not None:
             json["notify"] = self.notify
 
-        if self.disable_link_preview:
+        if self.disable_link_preview is not None:
             json["disable_link_preview"] = self.disable_link_preview
 
         if self.parse_mode is not None:
             json["format"] = self.parse_mode.value
 
-        if HAS_INPUT_MEDIA and self.sleep_after_input_media:
+        if has_input_media and self.sleep_after_input_media:
             await asyncio.sleep(bot.after_input_media_delay)
 
         response = None
@@ -137,7 +137,10 @@ class SendMessage(BaseConnection):
             except MaxApiError as e:
                 if "attachment.not.ready" in e.raw:
                     logger_bot.info(
-                        f"Ошибка при отправке загруженного медиа, попытка {attempt + 1}, жду {self.RETRY_DELAY} секунды"
+                        "Ошибка при отправке загруженного медиа, "
+                        "попытка %d, жду %d секунды",
+                        attempt + 1,
+                        self.RETRY_DELAY,
                     )
                     await asyncio.sleep(self.RETRY_DELAY)
                     continue

--- a/maxapi/types/input_media.py
+++ b/maxapi/types/input_media.py
@@ -1,36 +1,33 @@
 from __future__ import annotations
 
-import puremagic
-
 from ..enums.upload_type import UploadType
+from ..utils.media import detect_upload_type_from_bytes
 
 
 class InputMedia:
-    """
-    Класс для представления медиафайла.
+    """Класс для представления медиафайла.
 
     Attributes:
-        path (str): Путь к файлу.
-        type (UploadType): Тип файла, определенный на основе содержимого (MIME-типа).
+        path: Путь к файлу.
+        type: Тип файла, определенный на основе содержимого (MIME-типа).
     """
 
-    def __init__(self, path: str):
-        """
-        Инициализирует объект медиафайла.
+    def __init__(self, path: str) -> None:
+        """Инициализирует объект медиафайла.
 
         Args:
-            path (str): Путь к файлу.
+            path: Путь к файлу.
         """
 
         self.path = path
-        self.type = self.__detect_file_type(path)
+        self.type = self._detect_file_type(path)
 
-    def __detect_file_type(self, path: str) -> UploadType:
-        """
-        Определяет тип файла на основе его содержимого (MIME-типа).
+    @staticmethod
+    def _detect_file_type(path: str) -> UploadType:
+        """Определяет тип файла на основе его содержимого.
 
         Args:
-            path (str): Путь к файлу.
+            path: Путь к файлу.
 
         Returns:
             UploadType: Тип файла (VIDEO, IMAGE, AUDIO или FILE).
@@ -39,67 +36,28 @@ class InputMedia:
         with open(path, "rb") as f:
             sample = f.read(4096)
 
-        try:
-            matches = puremagic.magic_string(sample)
-            if matches:
-                mime_type = matches[0].mime_type
-            else:
-                mime_type = None
-        except Exception:
-            mime_type = None
-
-        if mime_type is None:
-            return UploadType.FILE
-
-        if mime_type.startswith("video/"):
-            return UploadType.VIDEO
-        elif mime_type.startswith("image/"):
-            return UploadType.IMAGE
-        elif mime_type.startswith("audio/"):
-            return UploadType.AUDIO
-        else:
-            return UploadType.FILE
+        return detect_upload_type_from_bytes(sample)
 
 
 class InputMediaBuffer:
-    """
-    Класс для представления медиафайла из буфера.
+    """Класс для представления медиафайла из буфера.
 
     Attributes:
-        buffer (bytes): Буфер с содержимым файла.
-        type (UploadType): Тип файла, определенный по содержимому.
+        buffer: Буфер с содержимым файла.
+        type: Тип файла, определенный по содержимому.
+        filename: Название файла.
     """
 
-    def __init__(self, buffer: bytes, filename: str | None = None):
-        """
-        Инициализирует объект медиафайла из буфера.
+    def __init__(
+        self, buffer: bytes, filename: str | None = None
+    ) -> None:
+        """Инициализирует объект медиафайла из буфера.
 
         Args:
-            buffer (IO): Буфер с содержимым файла.
-            filename (str): Название файла (по умолчанию присваивается uuid4).
+            buffer: Буфер с содержимым файла.
+            filename: Название файла (по умолчанию присваивается uuid4).
         """
 
         self.filename = filename
         self.buffer = buffer
-        self.type = self.__detect_file_type(buffer)
-
-    def __detect_file_type(self, buffer: bytes) -> UploadType:
-        try:
-            matches = puremagic.magic_string(buffer)
-            if matches:
-                mime_type = matches[0].mime_type
-            else:
-                mime_type = None
-        except Exception:
-            mime_type = None
-
-        if mime_type is None:
-            return UploadType.FILE
-        if mime_type.startswith("video/"):
-            return UploadType.VIDEO
-        elif mime_type.startswith("image/"):
-            return UploadType.IMAGE
-        elif mime_type.startswith("audio/"):
-            return UploadType.AUDIO
-        else:
-            return UploadType.FILE
+        self.type = detect_upload_type_from_bytes(buffer)

--- a/maxapi/types/updates/__init__.py
+++ b/maxapi/types/updates/__init__.py
@@ -3,7 +3,12 @@ from typing import Union
 from ...types.updates.bot_added import BotAdded
 from ...types.updates.bot_removed import BotRemoved
 from ...types.updates.bot_started import BotStarted
+from ...types.updates.bot_stopped import BotStopped
 from ...types.updates.chat_title_changed import ChatTitleChanged
+from ...types.updates.dialog_cleared import DialogCleared
+from ...types.updates.dialog_muted import DialogMuted
+from ...types.updates.dialog_removed import DialogRemoved
+from ...types.updates.dialog_unmuted import DialogUnmuted
 from ...types.updates.message_callback import MessageCallback
 from ...types.updates.message_chat_created import MessageChatCreated
 from ...types.updates.message_created import MessageCreated
@@ -16,7 +21,12 @@ UpdateUnion = Union[
     BotAdded,
     BotRemoved,
     BotStarted,
+    BotStopped,
     ChatTitleChanged,
+    DialogCleared,
+    DialogMuted,
+    DialogRemoved,
+    DialogUnmuted,
     MessageCallback,
     MessageChatCreated,
     MessageCreated,

--- a/maxapi/types/updates/bot_added.py
+++ b/maxapi/types/updates/bot_added.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Optional, Tuple
 
 from ...types.users import User
 from .update import Update
@@ -24,5 +24,5 @@ class BotAdded(Update):
     if TYPE_CHECKING:
         bot: Optional[Bot]  # pyright: ignore[reportGeneralTypeIssues]
 
-    def get_ids(self):
+    def get_ids(self) -> Tuple[Optional[int], Optional[int]]:
         return (self.chat_id, self.user.user_id)

--- a/maxapi/types/updates/bot_removed.py
+++ b/maxapi/types/updates/bot_removed.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Optional, Tuple
 
 from ...types.users import User
 from .update import Update
@@ -24,5 +24,5 @@ class BotRemoved(Update):
     if TYPE_CHECKING:
         bot: Optional[Bot]  # pyright: ignore[reportGeneralTypeIssues]
 
-    def get_ids(self):
+    def get_ids(self) -> Tuple[Optional[int], Optional[int]]:
         return (self.chat_id, self.user.user_id)

--- a/maxapi/types/updates/bot_started.py
+++ b/maxapi/types/updates/bot_started.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Optional, Tuple
 
 from ...types.users import User
 from .update import Update
@@ -26,5 +26,5 @@ class BotStarted(Update):
     if TYPE_CHECKING:
         bot: Optional[Bot]  # pyright: ignore[reportGeneralTypeIssues]
 
-    def get_ids(self):
+    def get_ids(self) -> Tuple[Optional[int], Optional[int]]:
         return (self.chat_id, self.user.user_id)

--- a/maxapi/types/updates/bot_stopped.py
+++ b/maxapi/types/updates/bot_stopped.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Optional, Tuple
 
 from ...types.users import User
 from .update import Update
@@ -26,5 +26,5 @@ class BotStopped(Update):
     if TYPE_CHECKING:
         bot: Optional[Bot]  # pyright: ignore[reportGeneralTypeIssues]
 
-    def get_ids(self):
+    def get_ids(self) -> Tuple[Optional[int], Optional[int]]:
         return (self.chat_id, self.user.user_id)

--- a/maxapi/types/updates/chat_title_changed.py
+++ b/maxapi/types/updates/chat_title_changed.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Optional, Tuple
 
 from ...types.users import User
 from .update import Update
@@ -24,5 +24,5 @@ class ChatTitleChanged(Update):
     if TYPE_CHECKING:
         bot: Optional[Bot]  # pyright: ignore[reportGeneralTypeIssues]
 
-    def get_ids(self):
+    def get_ids(self) -> Tuple[Optional[int], Optional[int]]:
         return (self.chat_id, self.user.user_id)

--- a/maxapi/types/updates/dialog_cleared.py
+++ b/maxapi/types/updates/dialog_cleared.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Optional, Tuple
 
 from ...types.users import User
 from .update import Update
@@ -24,5 +24,5 @@ class DialogCleared(Update):
     if TYPE_CHECKING:
         bot: Optional[Bot]  # pyright: ignore[reportGeneralTypeIssues]
 
-    def get_ids(self):
+    def get_ids(self) -> Tuple[Optional[int], Optional[int]]:
         return (self.chat_id, self.user.user_id)

--- a/maxapi/types/updates/dialog_muted.py
+++ b/maxapi/types/updates/dialog_muted.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Optional, Tuple
 
 from ...types.users import User
 from .update import Update
@@ -34,5 +34,5 @@ class DialogMuted(Update):
         except (OverflowError, OSError):
             return datetime.max
 
-    def get_ids(self):
+    def get_ids(self) -> Tuple[Optional[int], Optional[int]]:
         return (self.chat_id, self.user.user_id)

--- a/maxapi/types/updates/dialog_removed.py
+++ b/maxapi/types/updates/dialog_removed.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Optional, Tuple
 
 from ...types.users import User
 from .update import Update
@@ -24,5 +24,5 @@ class DialogRemoved(Update):
     if TYPE_CHECKING:
         bot: Optional[Bot]  # pyright: ignore[reportGeneralTypeIssues]
 
-    def get_ids(self):
+    def get_ids(self) -> Tuple[Optional[int], Optional[int]]:
         return (self.chat_id, self.user.user_id)

--- a/maxapi/types/updates/dialog_unmuted.py
+++ b/maxapi/types/updates/dialog_unmuted.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Optional, Tuple
 
 from ...types.users import User
 from .update import Update
@@ -24,5 +24,5 @@ class DialogUnmuted(Update):
     if TYPE_CHECKING:
         bot: Optional[Bot]  # pyright: ignore[reportGeneralTypeIssues]
 
-    def get_ids(self):
+    def get_ids(self) -> Tuple[Optional[int], Optional[int]]:
         return (self.chat_id, self.user.user_id)

--- a/maxapi/types/updates/message_callback.py
+++ b/maxapi/types/updates/message_callback.py
@@ -46,7 +46,7 @@ class MessageCallback(Update):
     user_locale: Optional[str] = None
     callback: Callback
 
-    def get_ids(self) -> Tuple[Optional[int], int]:
+    def get_ids(self) -> Tuple[Optional[int], Optional[int]]:
         """
         Возвращает кортеж идентификаторов (chat_id, user_id).
 

--- a/maxapi/types/updates/message_chat_created.py
+++ b/maxapi/types/updates/message_chat_created.py
@@ -1,5 +1,5 @@
 import warnings
-from typing import Optional
+from typing import Optional, Tuple
 
 from ...types.chats import Chat
 from .update import Update
@@ -32,5 +32,5 @@ class MessageChatCreated(Update):
             stacklevel=2,
         )
 
-    def get_ids(self):
+    def get_ids(self) -> Tuple[Optional[int], Optional[int]]:
         return (self.chat.chat_id, self.chat.owner_id)

--- a/maxapi/types/updates/message_created.py
+++ b/maxapi/types/updates/message_created.py
@@ -18,12 +18,13 @@ class MessageCreated(Update):
     message: Message
     user_locale: Optional[str] = None
 
-    def get_ids(self) -> Tuple[Optional[int], int]:
+    def get_ids(self) -> Tuple[Optional[int], Optional[int]]:
         """
         Возвращает кортеж идентификаторов (chat_id, user_id).
 
         Returns:
-            tuple[Optional[int], int]: Идентификатор чата и пользователя.
+            Tuple[Optional[int], Optional[int]]: Идентификатор чата и пользователя.
         """
 
-        return (self.message.recipient.chat_id, self.message.sender.user_id) # type: ignore
+        user_id = self.message.sender.user_id if self.message.sender else None
+        return (self.message.recipient.chat_id, user_id)

--- a/maxapi/types/updates/update.py
+++ b/maxapi/types/updates/update.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Optional
+from abc import abstractmethod
+from typing import TYPE_CHECKING, Any, Optional, Tuple
 
 from pydantic import BaseModel, Field
 
@@ -14,12 +15,11 @@ if TYPE_CHECKING:
 
 
 class Update(BaseModel, BotMixin):
-    """
-    Базовая модель обновления.
+    """Базовая модель обновления.
 
     Attributes:
-        update_type (UpdateType): Тип обновления.
-        timestamp (int): Временная метка обновления.
+        update_type: Тип обновления.
+        timestamp: Временная метка обновления.
     """
 
     update_type: UpdateType
@@ -36,3 +36,12 @@ class Update(BaseModel, BotMixin):
 
     class Config:
         arbitrary_types_allowed = True
+
+    @abstractmethod
+    def get_ids(self) -> Tuple[Optional[int], Optional[int]]:
+        """Возвращает кортеж идентификаторов (chat_id, user_id).
+
+        Returns:
+            Tuple[Optional[int], Optional[int]]: Идентификаторы чата и пользователя.
+        """
+        ...

--- a/maxapi/utils/media.py
+++ b/maxapi/utils/media.py
@@ -1,0 +1,53 @@
+"""Утилиты для определения типа медиафайлов."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import puremagic
+
+from ..enums.upload_type import UploadType
+
+
+def detect_upload_type_from_bytes(data: bytes) -> UploadType:
+    """Определяет тип файла по содержимому (magic bytes).
+
+    Args:
+        data: Байты файла (достаточно первых 4096).
+
+    Returns:
+        UploadType: Тип файла (VIDEO, IMAGE, AUDIO или FILE).
+    """
+
+    mime_type = _detect_mime(data)
+
+    if mime_type is None:
+        return UploadType.FILE
+
+    if mime_type.startswith("video/"):
+        return UploadType.VIDEO
+    elif mime_type.startswith("image/"):
+        return UploadType.IMAGE
+    elif mime_type.startswith("audio/"):
+        return UploadType.AUDIO
+    else:
+        return UploadType.FILE
+
+
+def _detect_mime(data: bytes) -> Optional[str]:
+    """Определяет MIME-тип по байтам.
+
+    Args:
+        data: Байты для анализа.
+
+    Returns:
+        Optional[str]: MIME-тип или None.
+    """
+
+    try:
+        matches = puremagic.magic_string(data)
+        if matches:
+            return matches[0].mime_type
+    except Exception:
+        pass
+    return None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,11 +9,12 @@ keywords = ["max", "api", "bot"]
 classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
     "aiohttp>=3.12.14",
     "magic_filter>=1.0.0",
-    "pydantic>=1.8.0",
+    "pydantic>=2.0",
     "aiofiles==24.1.0",
     "puremagic==1.30",
 ]
@@ -29,7 +30,7 @@ requires = ["setuptools>=68.0.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools.packages.find]
-include = ["maxapi*", "wiki*", "examples*"]
+include = ["maxapi*"]
 
 [project.optional-dependencies]
 webhook = ["fastapi>=0.68.0", "uvicorn>=0.15.0"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -182,6 +182,4 @@ def preserve_env_vars():
     if original_token:
         os.environ["MAX_BOT_TOKEN"] = original_token
     elif "MAX_BOT_TOKEN" in os.environ:
-        # Если токен был установлен в тесте, но не был до этого - удаляем
-        # Но только если он не был загружен из .env изначально
-        pass
+        del os.environ["MAX_BOT_TOKEN"]

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -23,7 +23,7 @@ class TestDispatcherInitialization:
         assert dp.use_create_task is False
         assert isinstance(dp.event_handlers, list)
         assert len(dp.event_handlers) == 0
-        assert isinstance(dp.contexts, list)
+        assert isinstance(dp.contexts, dict)
         assert isinstance(dp.routers, list)
         assert isinstance(dp.middlewares, list)
         assert dp.bot is None


### PR DESCRIPTION
## Критические исправления (P0)

### 1. `UpdateUnion` - добавлены недостающие типы обновлений
**Файл:** `maxapi/types/updates/__init__.py`

`UpdateUnion` не содержал 5 типов обновлений (`BotStopped`, `DialogCleared`, `DialogMuted`, `DialogUnmuted`, `DialogRemoved`), которые реально обрабатываются диспатчером и маппингом в `getted_updates.py`. Это приводило к некорректной типизации - тайпчекеры не могли отловить ошибки при работе с этими типами.

**Исправление:** добавлены все недостающие типы в `UpdateUnion`.

---

### 2. Ограничение версии Pydantic: `>=1.8.0` → `>=2.0`
**Файл:** `pyproject.toml`

Код использует API Pydantic v2 (`model_dump()`, `populate_by_name`, `model_config`), но зависимость `pydantic>=1.8.0` допускала установку Pydantic v1, что приводило к падению при импорте.

**Исправление:** изменено на `pydantic>=2.0`.

---

### 3. `MANIFEST.in` ссылался на несуществующий `LICENSE.md`
**Файл:** `MANIFEST.in`

Файл лицензии в проекте называется `LICENSE`, а не `LICENSE.md`. Сборка sdist завершалась с предупреждением.

**Исправление:** `include LICENSE.md` → `include LICENSE`.

---

### 4. `MessageCreated.get_ids()` - `AttributeError` при `sender=None`
**Файл:** `maxapi/types/updates/message_created.py`

Поле `sender` типа `Optional[User]` может быть `None` (при отправке каналом), но `get_ids()` безусловно обращался к `self.message.sender.user_id`, маскируя проблему через `# type: ignore`.

**Исправление:** безопасное обращение с проверкой `if self.message.sender`.

---

### 5. `notify=False` не передавался в API
**Файл:** `maxapi/methods/send_message.py`

Проверка `if self.notify:` игнорировала значение `False` (т.к. оно falsy). Пользователь не мог явно отключить уведомления. Аналогично для `disable_link_preview`.

**Исправление:** `if self.notify:` → `if self.notify is not None:`, аналогично для `disable_link_preview`.

---

## Серьёзные исправления (P1)

### 6. `MaxApiError.raw` - неправильный тип `str` вместо `Any`
**Файл:** `maxapi/exceptions/max.py`

Поле `raw` объявлено как `str`, но фактически присваивается `dict` (результат `await r.json()`). Это ломало проверку `"attachment.not.ready" in e.raw` с точки зрения типизации.

**Исправление:** тип изменён на `Any`, добавлен docstring.

---

### 7. O(n) поиск контекстов → O(1) через `Dict`
**Файл:** `maxapi/dispatcher.py`

`MemoryContext` хранились в `List` и искались перебором. При большом числе пользователей это деградировало в O(n) на каждый запрос.

**Исправление:** `List[MemoryContext]` заменён на `Dict[tuple[int | None, int | None], MemoryContext]` с O(1) поиском через `.get()`.

---

### 8. Дублирование `__detect_file_type` → вынесено в утилиту
**Файлы:** `maxapi/types/input_media.py`, **новый** `maxapi/utils/media.py`

Метод определения типа файла по magic bytes дублировался в `InputMedia` и `InputMediaBuffer` почти идентично (DRY-нарушение).

**Исправление:** логика вынесена в `maxapi/utils/media.py` → `detect_upload_type_from_bytes()`. Оба класса используют общую функцию.

---

### 9. Дублирование логики upload-сессии
**Файл:** `maxapi/connection/base.py`

Паттерн «если сессия жива - используем её, иначе - временную» дублировался в `upload_file` и `upload_file_buffer`.

**Исправление:** вынесен в приватный метод `_post_form()`.

---

### 10. Fire-and-forget задачи без обработки исключений
**Файл:** `maxapi/connection/base.py`

`asyncio.create_task()` вызывался без сохранения ссылки на задачу. При исключении Python выдавал "Task exception was never retrieved".

**Исправление:** добавлен `_fire_raw_response()` с callback `_handle_bg_task_result()`, который логирует исключения через `logger_connection`.

---

## Улучшения (P2)

### 11. `State.__hash__` - восстановлена хешируемость
**Файл:** `maxapi/context/state_machine.py`

Класс `State` переопределял `__eq__`, что по PEP делало его unhashable. Нельзя было использовать `State` в `set` или как ключ `dict`.

**Исправление:** добавлены `__hash__` (на основе `self.name`) и `__repr__`.

---

### 12. f-строки в логгере → lazy-форматирование
**Файлы:** `maxapi/dispatcher.py`, `maxapi/methods/send_message.py`, `maxapi/methods/edit_message.py`

f-строки в вызовах `logger.info(f"...")` выполняют форматирование даже если уровень логирования отключён.

**Исправление:** заменены на `logger.info("...", arg1, arg2)` (%-стиль).

---

### 13. Абстрактный `get_ids()` в базовом классе `Update`
**Файлы:** `maxapi/types/updates/update.py` + все наследники

Все наследники `Update` реализуют `get_ids()`, но базовый класс не объявлял контракт. Забытая реализация в новом типе обнаруживалась только в рантайме.

**Исправление:** добавлен `@abstractmethod get_ids()` в `Update`. Все наследники аннотированы `-> Tuple[Optional[int], Optional[int]]`.

---

### 14. Параметр `id` затенял встроенную функцию
**Файл:** `maxapi/bot.py` - `get_chat_by_id()`

**Исправление:** `id` → `chat_id`.

---

### 15. Переменная `HAS_INPUT_MEDIA` в UPPER_CASE
**Файлы:** `maxapi/methods/send_message.py`, `maxapi/methods/edit_message.py`

UPPER_CASE зарезервирован для констант модуля.

**Исправление:** `HAS_INPUT_MEDIA` → `has_input_media`.

---

### 16. Двойной `.lower()` в `Command.__call__`
**Файл:** `maxapi/filters/command.py`

Команды уже приводились к нижнему регистру в `__init__`, но `.lower()` вызывался повторно при проверке.

**Исправление:** убран лишний `.lower()` в list comprehension.

---

### 17. `include_routers` - лишняя обёртка списка
**Файл:** `maxapi/dispatcher.py`

`self.routers += [r for r in routers]` - бессмысленная копия.

**Исправление:** `self.routers.extend(routers)`.

---

### 18. Мёртвый код в `conftest.py`
**Файл:** `tests/conftest.py`

Ветка `elif` с `pass` - ничего не делала, хотя по комментарию должна была удалять переменную окружения.

**Исправление:** заменено на `del os.environ["MAX_BOT_TOKEN"]`.

---

### 19. `pyproject.toml` - classifiers без Python 3.12
**Файл:** `pyproject.toml`

**Исправление:** добавлен `"Programming Language :: Python :: 3.12"`.

---

### 20. `pyproject.toml` - лишние пакеты в `setuptools.packages.find`
**Файл:** `pyproject.toml`

`wiki*` и `examples*` включались в дистрибутив, хотя не являются частью библиотеки.

**Исправление:** оставлен только `maxapi*`.

---

### 21. `edit_message.py` - `isinstance(att, InputMedia) or isinstance(att, InputMediaBuffer)`
**Файл:** `maxapi/methods/edit_message.py`

**Исправление:** объединено в `isinstance(att, (InputMedia, InputMediaBuffer))`.

---

## Затронутые файлы

| Файл | Тип изменения |
|------|---------------|
| `maxapi/types/updates/__init__.py` | Добавлены недостающие типы в UpdateUnion |
| `maxapi/types/updates/update.py` | Добавлен абстрактный `get_ids()` |
| `maxapi/types/updates/bot_added.py` | Аннотация `get_ids()` |
| `maxapi/types/updates/bot_removed.py` | Аннотация `get_ids()` |
| `maxapi/types/updates/bot_started.py` | Аннотация `get_ids()` |
| `maxapi/types/updates/bot_stopped.py` | Аннотация `get_ids()` |
| `maxapi/types/updates/chat_title_changed.py` | Аннотация `get_ids()` |
| `maxapi/types/updates/dialog_cleared.py` | Аннотация `get_ids()` |
| `maxapi/types/updates/dialog_muted.py` | Аннотация `get_ids()` |
| `maxapi/types/updates/dialog_unmuted.py` | Аннотация `get_ids()` |
| `maxapi/types/updates/dialog_removed.py` | Аннотация `get_ids()` |
| `maxapi/types/updates/message_callback.py` | Унификация типа `get_ids()` |
| `maxapi/types/updates/message_chat_created.py` | Аннотация `get_ids()` |
| `maxapi/types/updates/message_created.py` | Безопасный доступ к sender |
| `maxapi/types/input_media.py` | Рефакторинг: вынос detect_file_type |
| `maxapi/utils/media.py` | **Новый файл**: утилита определения типа медиа |
| `maxapi/connection/base.py` | Рефакторинг: _post_form, fire-and-forget, логирование |
| `maxapi/dispatcher.py` | Dict для контекстов, lazy logging, extend |
| `maxapi/bot.py` | Переименование параметра `id` → `chat_id` |
| `maxapi/methods/send_message.py` | notify is not None, has_input_media, lazy logging |
| `maxapi/methods/edit_message.py` | has_input_media, isinstance, lazy logging |
| `maxapi/filters/command.py` | Убран двойной .lower() |
| `maxapi/context/state_machine.py` | Добавлен __hash__, __repr__ |
| `maxapi/exceptions/max.py` | raw: str → Any, docstring |
| `pyproject.toml` | pydantic>=2.0, classifiers, packages.find |
| `MANIFEST.in` | LICENSE.md → LICENSE |
| `tests/conftest.py` | Исправлен dead code |
| `tests/test_dispatcher.py` | Обновлён тест: contexts теперь dict |
