### PR TITLE
Добавлено управление поведением при отсутствии исходного сообщения 

### DIFF
--- a/maxapi/types/updates/message_callback.py
+++ b/maxapi/types/updates/message_callback.py
@@ -69,6 +69,7 @@ class MessageCallback(Update):
         link: Optional[NewMessageLink] = None,
         notify: bool = True,
         format: Optional[ParseMode] = None,
+        raise_if_not_exists: bool = True,
     ) -> "SendedCallback":
         """
         Отправляет ответ на callback с возможностью изменить текст, вложения и параметры уведомления.
@@ -79,17 +80,45 @@ class MessageCallback(Update):
             link (Optional[NewMessageLink]): Связь с другим сообщением.
             notify (bool): Отправлять ли уведомление.
             format (Optional[ParseMode]): Режим разбора текста.
+            raise_if_not_exists: Выдавать ошибку при отсутствии сообщения,
+                если пытаются изменить его содержимое (new_text/link/format).
 
         Returns:
             SendedCallback: Результат вызова send_callback бота.
         """
 
+        # Если исходного сообщения нет (например, оно удалено), не стоит синтезировать
+        # пустой payload message. Два варианта поведения:
+        #  - если вызывающий просит изменить сообщение (new_text/link/format)
+        #    => выбросить исключение
+        #  - иначе отправить только notification с message=None, чтобы API не получил
+        #    пустой объект message
+        original_body = None
+        if self.message is not None:
+            original_body = self.message.body
+
+        if original_body is None:
+            # если пытаются изменить контент/вложение/связь
+            if (
+                raise_if_not_exists
+                and (new_text is not None or link is not None or format is not None)
+            ):
+                raise ValueError(
+                    "Невозможно изменить сообщение: исходное сообщение отсутствует"
+                )
+
+            # отправляем только уведомление (без поля message)
+            return await self._ensure_bot().send_callback(
+                callback_id=self.callback.callback_id,
+                message=None,
+                notification=notification,
+            )
+
+        # Если исходное сообщение есть — собираем MessageForCallback на его основе
         message_for_callback = MessageForCallback()
         message_for_callback.text = new_text
 
-        attachments: List[Attachments] = []
-        if self.message is not None and self.message.body is not None:
-            attachments = self.message.body.attachments or []
+        attachments: List[Attachments] = original_body.attachments or []
 
         message_for_callback.attachments = attachments
         message_for_callback.link = link

--- a/tests/test_messagecallback_none.py
+++ b/tests/test_messagecallback_none.py
@@ -13,8 +13,12 @@ class DummyBot:
     def _ensure_bot(self):
         return self
 
-    async def send_callback(self, callback_id: str, message: MessageForCallback,
-                            notification=None):
+    async def send_callback(
+            self,
+            callback_id: str,
+            message: MessageForCallback,
+            notification=None,
+    ):
         self.last = {
             "callback_id": callback_id,
             "message": message,
@@ -42,7 +46,7 @@ def test_get_ids_with_no_message(cb_obj):
     assert ids[1] == 42
 
 
-async def test_answer_with_no_message(cb_obj):
+async def test_answer_with_no_message_raises_on_change(cb_obj):
     mc = MessageCallback(
         message=None,
         user_locale=None,
@@ -53,8 +57,17 @@ async def test_answer_with_no_message(cb_obj):
     bot = DummyBot()
     mc.bot = bot
 
-    res = await mc.answer(notification="n", new_text="text")
+    with pytest.raises(ValueError):
+        await mc.answer(notification="n", new_text="text")
+
+
+async def test_answer_with_no_message_notification_only(cb_obj):
+    mc = MessageCallback(message=None, user_locale=None, callback=cb_obj, update_type=UpdateType.MESSAGE_CALLBACK, timestamp=1)
+    bot = DummyBot()
+    mc.bot = bot
+
+    res = await mc.answer(notification="n")
     assert res == {"ok": True}
     assert bot.last["callback_id"] == "cb1"
-    assert bot.last["message"].text == "text"
+    assert bot.last["message"] is None
     assert bot.last["notification"] == "n"


### PR DESCRIPTION
closes #30 

Добавлено управление поведением при отсутствии исходного сообщения в методе send_callback. 
Можно выбрасывать исключение или отправлять уведомление без сообщения