### PR TITLE
Оптимизация Dispatcher

### DIFF
--- a/maxapi/bot.py
+++ b/maxapi/bot.py
@@ -233,6 +233,10 @@ class Bot(BaseConnection):
 
         return self._me
 
+    @me.setter
+    def me(self, value: User | None) -> None:
+        self._me = value
+
     def _resolve_disable_link_preview(
         self, *, disable_link_preview: bool | None
     ) -> bool | None:

--- a/maxapi/dispatcher.py
+++ b/maxapi/dispatcher.py
@@ -165,7 +165,10 @@ class Dispatcher(BotMixin):
         bot.me = me
 
         logger_dp.info(
-            f"Бот: @{me.username} first_name={me.first_name} id={me.user_id}"
+            "Бот: @%s first_name=%s id=%s",
+            me.username,
+            me.first_name,
+            me.user_id,
         )
 
     @staticmethod
@@ -287,7 +290,7 @@ class Dispatcher(BotMixin):
         )
 
         logger_dp.info(
-            f"Зарегистрировано {handlers_count} обработчиков событий"
+            "Зарегистрировано %d обработчиков событий", handlers_count
         )
 
     @staticmethod
@@ -692,7 +695,7 @@ class Dispatcher(BotMixin):
                     )
                 except Exception as e:  # noqa: PERF203
                     logger_dp.exception(
-                        f"Ошибка в обработчике RAW_API_RESPONSE: {e}"
+                        "Ошибка в обработчике RAW_API_RESPONSE: %r", e
                     )
 
     async def _run_router_handlers(
@@ -731,7 +734,7 @@ class Dispatcher(BotMixin):
                 process_info=process_info,
             )
             logger_dp.info(
-                f"Обработано: router_id: {router_id} | {process_info}"
+                "Обработано: router_id: %s | %s", router_id, process_info
             )
             return True
         return False
@@ -866,6 +869,22 @@ class Dispatcher(BotMixin):
 
         return router_id, False
 
+    def _on_background_task_done(self, task: asyncio.Task) -> None:
+        """Callback завершения фоновой задачи (use_create_task=True).
+
+        Удаляет задачу из пула и логирует необработанное исключение, если оно
+        есть. Без явного вызова ``task.exception()`` Python при сборке мусора
+        выдаст предупреждение *"Task exception was never retrieved"*.
+        """
+        self._background_tasks.discard(task)
+        if not task.cancelled():
+            exc = task.exception()
+            if exc is not None:
+                logger_dp.exception(
+                    "Необработанное исключение в фоновой задаче handle(): %r",
+                    exc,
+                )
+
     @staticmethod
     def _get_middleware_title(chain: Any) -> str:
         """Определяет имя middleware для диагностики."""
@@ -957,13 +976,17 @@ class Dispatcher(BotMixin):
 
             if not is_handled:
                 logger_dp.info(
-                    f"Проигнорировано: router_id: {router_id} | {process_info}"
+                    "Проигнорировано: router_id: %s | %s",
+                    router_id,
+                    process_info,
                 )
 
         except Exception as e:
             logger_dp.exception(
-                f"Ошибка при обработке события: router_id: "
-                f"{router_id} | {process_info} | {e} "
+                "Ошибка при обработке события: router_id: %s | %s | %r",
+                router_id,
+                process_info,
+                e,
             )
 
     async def _fetch_updates_once(self, bot: Bot) -> dict | None:
@@ -982,8 +1005,10 @@ class Dispatcher(BotMixin):
             return None
         except (MaxConnection, ClientConnectorError) as e:
             logger_dp.warning(
-                f"Ошибка подключения при получении обновлений: {e}, "
-                f"жду {CONNECTION_RETRY_DELAY} секунд"
+                "Ошибка подключения при получении обновлений: %r, "
+                "жду %s секунд",
+                e,
+                CONNECTION_RETRY_DELAY,
             )
             await asyncio.sleep(CONNECTION_RETRY_DELAY)
             return None
@@ -993,15 +1018,16 @@ class Dispatcher(BotMixin):
             raise
         except MaxApiError as e:
             logger_dp.info(
-                f"Ошибка при получении обновлений: {e}, "
-                f"жду {GET_UPDATES_RETRY_DELAY} секунд"
+                "Ошибка при получении обновлений: %r, жду %s секунд",
+                e,
+                GET_UPDATES_RETRY_DELAY,
             )
             await asyncio.sleep(GET_UPDATES_RETRY_DELAY)
             return None
         except Exception as e:
             logger_dp.error(
-                f"Неожиданная ошибка при получении обновлений: "
-                f"{e.__class__.__name__}: {e}"
+                "Неожиданная ошибка при получении обновлений: %r",
+                e,
             )
             await asyncio.sleep(GET_UPDATES_RETRY_DELAY)
             return None
@@ -1025,26 +1051,28 @@ class Dispatcher(BotMixin):
             for event in processed_events:
                 if skip_updates and event.timestamp < current_timestamp:
                     logger_dp.info(
-                        f"Пропуск события от {from_ms(event.timestamp)}: "
-                        f"{event.update_type}"
+                        "Пропуск события от %s: %s",
+                        from_ms(event.timestamp),
+                        event.update_type,
                     )
                     continue
 
                 if self.use_create_task:
                     task = asyncio.create_task(self.handle(event))
                     self._background_tasks.add(task)
-                    task.add_done_callback(self._background_tasks.discard)
+                    task.add_done_callback(self._on_background_task_done)
                 else:
                     await self.handle(event)
 
         except ClientConnectorError:
             logger_dp.error(
-                f"Ошибка подключения, жду {CONNECTION_RETRY_DELAY} секунд"
+                "Ошибка подключения, жду %s секунд", CONNECTION_RETRY_DELAY
             )
             await asyncio.sleep(CONNECTION_RETRY_DELAY)
         except Exception as e:
             logger_dp.error(
-                f"Общая ошибка при обработке событий: {e.__class__} - {e}"
+                "Общая ошибка при обработке событий: %r",
+                e,
             )
 
     async def start_polling(
@@ -1084,8 +1112,8 @@ class Dispatcher(BotMixin):
 
         if self._background_tasks:
             logger_dp.info(
-                f"Ожидаю завершения {len(self._background_tasks)} "
-                f"фоновых задач..."
+                "Ожидаю завершения %d фоновых задач...",
+                len(self._background_tasks),
             )
             await asyncio.gather(
                 *self._background_tasks, return_exceptions=True

--- a/maxapi/dispatcher.py
+++ b/maxapi/dispatcher.py
@@ -4,8 +4,9 @@ import asyncio
 import functools
 import warnings
 from asyncio.exceptions import TimeoutError as AsyncioTimeoutError
+from collections import OrderedDict
 from datetime import datetime
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any
 from warnings import warn
 
 from aiohttp import ClientConnectorError
@@ -36,6 +37,7 @@ if TYPE_CHECKING:
 
 CONNECTION_RETRY_DELAY = 30
 GET_UPDATES_RETRY_DELAY = 5
+CONTEXTS_MAX_SIZE = 10_000
 
 
 class Dispatcher(BotMixin):
@@ -72,7 +74,10 @@ class Dispatcher(BotMixin):
         self.storage_kwargs = storage_kwargs
 
         self.event_handlers: list[Handler] = []
-        self.contexts: dict[tuple[int | None, int | None], BaseContext] = {}
+        self.handlers_by_type: dict[UpdateType, list[Handler]] | None = None
+        self.contexts: OrderedDict[
+            tuple[int | None, int | None], BaseContext
+        ] = OrderedDict()
         self.routers: list[Router | Dispatcher] = []
         self.filters: list[MagicFilter] = []
         self.base_filters: list[BaseFilter] = []
@@ -82,6 +87,21 @@ class Dispatcher(BotMixin):
         self.on_started_func: Callable | None = None
         self.polling = False
         self.use_create_task = use_create_task
+        self._cached_router_entries: (
+            list[
+                tuple[
+                    Router | Dispatcher,
+                    list[BaseMiddleware],
+                    list[MagicFilter],
+                    list[BaseFilter],
+                ]
+            ]
+            | None
+        ) = None
+        self._global_mw_chain: (
+            Callable[[Any, dict[str, Any]], Awaitable[Any]] | None
+        ) = None
+        self._background_tasks: set[asyncio.Task] = set()
 
         self.message_created = Event(
             update_type=UpdateType.MESSAGE_CREATED, router=self
@@ -139,16 +159,17 @@ class Dispatcher(BotMixin):
         Проверяет и логирует информацию о боте.
         """
 
-        me = await self._ensure_bot().get_me()
+        bot = self._ensure_bot()
+        me = await bot.get_me()
 
-        self._ensure_bot()._me = me  # noqa: SLF001
+        bot.me = me
 
         logger_dp.info(
             f"Бот: @{me.username} first_name={me.first_name} id={me.user_id}"
         )
 
+    @staticmethod
     def build_middleware_chain(
-        self,
         middlewares: list[BaseMiddleware],
         handler: Callable[[Any, dict[str, Any]], Awaitable[Any]],
     ) -> Callable[[Any, dict[str, Any]], Awaitable[Any]]:
@@ -228,11 +249,15 @@ class Dispatcher(BotMixin):
         self.routers += [self]
         self._prepare_handlers(bot)
 
+        self._global_mw_chain = self.build_middleware_chain(
+            self.middlewares, self._process_event
+        )
+
         if self.on_started_func:
             await self.on_started_func()
 
     def _prepare_handlers(self, bot: Bot) -> None:
-        """Подготовить обработчики событий."""
+        """Подготовить обработчики событий и построить кеши."""
 
         handlers_count = 0
 
@@ -240,10 +265,26 @@ class Dispatcher(BotMixin):
             self.routers, warn_duplicates=True
         ):
             router.bot = bot
+            router.handlers_by_type = {}
 
             for handler in router.event_handlers:
                 handlers_count += 1
                 extract_commands(handler, bot)
+
+                handler.func_args = frozenset(
+                    handler.func_event.__annotations__,
+                )
+                handler.mw_chain = self.build_middleware_chain(
+                    handler.middlewares,
+                    functools.partial(self.call_handler, handler),
+                )
+                router.handlers_by_type.setdefault(
+                    handler.update_type, []
+                ).append(handler)
+
+        self._cached_router_entries = list(
+            self._iter_unique_routers(self.routers)
+        )
 
         logger_dp.info(
             f"Зарегистрировано {handlers_count} обработчиков событий"
@@ -280,15 +321,22 @@ class Dispatcher(BotMixin):
         """
 
         key = (chat_id, user_id)
-        if key in self.contexts:
-            return self.contexts[key]
+        ctx = self.contexts.get(key)
+        if ctx is not None:
+            # Перемещаем в конец, чтобы LRU-вытеснение удаляло
+            # самые давно неиспользованные контексты
+            self.contexts.move_to_end(key)
+            return ctx
+
+        if len(self.contexts) >= CONTEXTS_MAX_SIZE:
+            self.contexts.popitem(last=False)
 
         new_ctx = self.storage(chat_id, user_id, **self.storage_kwargs)
         self.contexts[key] = new_ctx
         return new_ctx
 
+    @staticmethod
     async def call_handler(
-        self,
         handler: Handler,
         event_object: UpdateType | dict[str, Any],
         data: dict[str, Any],
@@ -299,23 +347,21 @@ class Dispatcher(BotMixin):
         Args:
             handler: Handler.
             event_object: Объект события.
-            data: Данные для хендлера.
+            data: Уже отфильтрованные данные для хендлера.
 
         Returns:
             None
         """
 
-        func_args = handler.func_event.__annotations__.keys()
-        kwargs_filtered = {k: v for k, v in data.items() if k in func_args}
-
-        if kwargs_filtered:
-            await handler.func_event(event_object, **kwargs_filtered)
+        if data:
+            await handler.func_event(event_object, **data)
         else:
             await handler.func_event(event_object)
 
+    @staticmethod
     async def process_base_filters(
-        self, event: UpdateUnion, filters: list[BaseFilter]
-    ) -> dict[str, Any] | None | Literal[False]:
+        event: UpdateUnion, filters: list[BaseFilter]
+    ) -> dict[str, Any] | None:
         """
         Асинхронно применяет фильтры к событию.
 
@@ -324,11 +370,11 @@ class Dispatcher(BotMixin):
             filters (List[BaseFilter]): Список фильтров.
 
         Returns:
-            Optional[Dict[str, Any]] | Literal[False]: Словарь с
-                результатом или False.
+            dict[str, Any] | None: Словарь с результатом или None,
+                если фильтр не прошёл.
         """
 
-        data = {}
+        data: dict[str, Any] = {}
 
         for _filter in filters:
             result = await _filter(event)
@@ -337,7 +383,7 @@ class Dispatcher(BotMixin):
                 data.update(result)
 
             elif not result:
-                return result
+                return None
 
         return data
 
@@ -375,27 +421,26 @@ class Dispatcher(BotMixin):
             Кортеж (роутер, middleware, MagicFilter, BaseFilter) с накопленными
             значениями от всех родителей.
         """
-        parent_middlewares = parent_middlewares or []
-        parent_filters = parent_filters or []
-        parent_base_filters = parent_base_filters or []
-        path = path if path is not None else set()
+        middlewares = parent_middlewares or []
+        filters = parent_filters or []
+        base_filters = parent_base_filters or []
+
+        if path is None:
+            path = set()
 
         for router in routers:
             router_key = id(router)
             if router_key in path:
                 continue
 
+            accumulated_middlewares: list[BaseMiddleware]
             if router is self:
-                accumulated_middlewares = parent_middlewares
+                accumulated_middlewares = middlewares
             else:
-                accumulated_middlewares = (
-                    parent_middlewares + router.middlewares
-                )
+                accumulated_middlewares = middlewares + router.middlewares
 
-            accumulated_filters = parent_filters + router.filters
-            accumulated_base_filters = (
-                parent_base_filters + router.base_filters
-            )
+            accumulated_filters = filters + router.filters
+            accumulated_base_filters = base_filters + router.base_filters
 
             yield (
                 router,
@@ -493,7 +538,7 @@ class Dispatcher(BotMixin):
         event: UpdateUnion,
         filters: list[MagicFilter],
         base_filters: list[BaseFilter],
-    ) -> dict[str, Any] | Literal[False]:
+    ) -> dict[str, Any] | None:
         """
         Проверяет накопленные фильтры роутера для события.
 
@@ -503,25 +548,22 @@ class Dispatcher(BotMixin):
             base_filters: Накопленные BaseFilter.
 
         Returns:
-            Dict[str, Any] | Literal[False]: Словарь с данными или False,
+            dict[str, Any] | None: Словарь с данными или None,
                 если фильтры не прошли.
         """
         if filters and not filter_attrs(event, *filters):
-            return False
+            return None
 
         if base_filters:
-            result = await self.process_base_filters(
+            return await self.process_base_filters(
                 event=event, filters=base_filters
             )
-            if isinstance(result, dict):
-                return result
-            if not result:
-                return False
 
         return {}
 
+    @staticmethod
     def _find_matching_handlers(
-        self, router: Router | Dispatcher, event_type: UpdateType
+        router: Router | Dispatcher, event_type: UpdateType
     ) -> list[Handler]:
         """
         Находит обработчики, соответствующие типу события в роутере.
@@ -533,6 +575,10 @@ class Dispatcher(BotMixin):
         Returns:
             List[Handler]: Список подходящих обработчиков.
         """
+        index = router.handlers_by_type
+        if index is not None:
+            return index.get(event_type, [])
+
         return [
             handler
             for handler in router.event_handlers
@@ -544,7 +590,7 @@ class Dispatcher(BotMixin):
         handler: Handler,
         event: UpdateUnion,
         current_state: Any | None,
-    ) -> dict[str, Any] | None | Literal[False]:
+    ) -> dict[str, Any] | None:
         """
         Проверяет, подходит ли обработчик для события (фильтры, состояние).
 
@@ -554,25 +600,17 @@ class Dispatcher(BotMixin):
             current_state (Optional[Any]): Текущее состояние.
 
         Returns:
-            Optional[Dict[str, Any]] | Literal[False]: Словарь с данными
-                или False, если не подходит.
+            dict[str, Any] | None: Словарь с данными или None,
+                если не подходит.
         """
-        if handler.filters and not filter_attrs(event, *handler.filters):
-            return False
-
         if handler.states and current_state not in handler.states:
-            return False
+            return None
 
-        if handler.base_filters:
-            result = await self.process_base_filters(
-                event=event, filters=handler.base_filters
-            )
-            if isinstance(result, dict):
-                return result
-            if not result:
-                return False
-
-        return {}
+        return await self._check_router_filters(
+            event=event,
+            filters=handler.filters,
+            base_filters=handler.base_filters,
+        )
 
     async def _execute_handler(
         self,
@@ -603,13 +641,13 @@ class Dispatcher(BotMixin):
         Raises:
             HandlerException: При ошибке выполнения обработчика.
         """
-        func_args = handler.func_event.__annotations__.keys()
+        func_args = (
+            handler.func_args
+            or getattr(handler.func_event, "__annotations__", {}).keys()
+        )
         kwargs_filtered = {k: v for k, v in data.items() if k in func_args}
 
-        if "context" not in kwargs_filtered and "context" in data:
-            kwargs_filtered["context"] = data["context"]
-
-        handler_chain = self.build_middleware_chain(
+        handler_chain = handler.mw_chain or self.build_middleware_chain(
             handler_middlewares,
             functools.partial(self.call_handler, handler),
         )
@@ -635,17 +673,233 @@ class Dispatcher(BotMixin):
         """
         Специальный метод для обработки сырых ответов API.
         """
-        for router, *_ in self._iter_unique_routers(self.routers):
+        entries = (
+            self._cached_router_entries
+            if self._cached_router_entries is not None
+            else self._iter_unique_routers(self.routers)
+        )
+        for router, *_ in entries:
             matching_handlers = self._find_matching_handlers(
-                router, event_type
+                router=router,
+                event_type=event_type,
             )
             for handler in matching_handlers:
                 try:
-                    await self.call_handler(handler, raw_data, {})
+                    await self.call_handler(
+                        handler=handler,
+                        event_object=raw_data,
+                        data={},
+                    )
                 except Exception as e:  # noqa: PERF203
                     logger_dp.exception(
                         f"Ошибка в обработчике RAW_API_RESPONSE: {e}"
                     )
+
+    async def _run_router_handlers(
+        self,
+        event: UpdateUnion,
+        data: dict[str, Any],
+        matching_handlers: list[Handler],
+        memory_context: BaseContext,
+        current_state: Any | None,
+        router_id: Any,
+        process_info: str,
+    ) -> bool:
+        """
+        Перебирает обработчики роутера и выполняет первый подходящий.
+
+        Returns:
+            bool: True если обработчик был выполнен.
+        """
+        for handler in matching_handlers:
+            handler_match_result = await self._check_handler_match(
+                handler=handler,
+                event=event,
+                current_state=current_state,
+            )
+            if handler_match_result is None:
+                continue
+            data.update(handler_match_result)
+            await self._execute_handler(
+                handler=handler,
+                event=event,
+                data=data,
+                handler_middlewares=handler.middlewares,
+                memory_context=memory_context,
+                current_state=current_state,
+                router_id=router_id,
+                process_info=process_info,
+            )
+            logger_dp.info(
+                f"Обработано: router_id: {router_id} | {process_info}"
+            )
+            return True
+        return False
+
+    async def _invoke_router_handlers(
+        self,
+        event: UpdateUnion,
+        handler_data: dict[str, Any],
+        *,
+        matching_handlers: list[Handler],
+        memory_context: BaseContext,
+        current_state: Any | None,
+        router_id: Any,
+        process_info: str,
+    ) -> None:
+        """
+        Endpoint middleware-цепочки роутера: вызывает подходящий обработчик.
+
+        Args:
+            event (UpdateUnion): Событие.
+            handler_data (dict): Данные для обработчика.
+            matching_handlers: Обработчики роутера для данного типа события.
+            memory_context: Контекст памяти.
+            current_state: Текущее состояние.
+            router_id: Идентификатор роутера для логов.
+            process_info: Информация о процессе для логов.
+        """
+        if await self._run_router_handlers(
+            event=event,
+            data=handler_data,
+            matching_handlers=matching_handlers,
+            memory_context=memory_context,
+            current_state=current_state,
+            router_id=router_id,
+            process_info=process_info,
+        ):
+            handler_data["_handled"] = True
+
+    async def _dispatch_to_router(
+        self,
+        event_object: UpdateUnion,
+        data: dict[str, Any],
+        matching_handlers: list[Handler],
+        router_middlewares: list[BaseMiddleware],
+        memory_context: BaseContext,
+        current_state: Any | None,
+        router_id: Any,
+        process_info: str,
+    ) -> bool:
+        """
+        Диспатчит событие через middleware одного роутера.
+
+        Returns:
+            bool: True если событие было обработано.
+        """
+        data["_handled"] = False
+
+        process_fn = functools.partial(
+            self._invoke_router_handlers,
+            matching_handlers=matching_handlers,
+            memory_context=memory_context,
+            current_state=current_state,
+            router_id=router_id,
+            process_info=process_info,
+        )
+
+        if router_middlewares:
+            chain = self.build_middleware_chain(router_middlewares, process_fn)
+            await chain(event_object, data)
+        else:
+            await process_fn(event_object, data)
+
+        return data.pop("_handled", False)
+
+    async def _iter_and_dispatch_routers(
+        self,
+        event_object: UpdateUnion,
+        data: dict[str, Any],
+        memory_context: BaseContext,
+        current_state: Any | None,
+        process_info: str,
+    ) -> tuple[Any, bool]:
+        """
+        Перебирает все роутеры и диспетчеризует событие.
+
+        Returns:
+            tuple[Any, bool]: (router_id, is_handled)
+        """
+        router_id = None
+
+        entries = (
+            self._cached_router_entries
+            if self._cached_router_entries is not None
+            else self._iter_unique_routers(self.routers)
+        )
+
+        for (
+            router,
+            router_middlewares,
+            router_filters,
+            router_base_filters,
+        ) in entries:
+            router_id = router.router_id or id(router)
+
+            router_filter_result = await self._check_router_filters(
+                event=event_object,
+                filters=router_filters,
+                base_filters=router_base_filters,
+            )
+            if router_filter_result is None:
+                continue
+            data.update(router_filter_result)
+
+            matching_handlers = self._find_matching_handlers(
+                router=router,
+                event_type=event_object.update_type,
+            )
+            if not matching_handlers:
+                continue
+
+            if await self._dispatch_to_router(
+                event_object=event_object,
+                data=data,
+                matching_handlers=matching_handlers,
+                router_middlewares=router_middlewares,
+                memory_context=memory_context,
+                current_state=current_state,
+                router_id=router_id,
+                process_info=process_info,
+            ):
+                return router_id, True
+
+        return router_id, False
+
+    @staticmethod
+    def _get_middleware_title(chain: Any) -> str:
+        """Определяет имя middleware для диагностики."""
+        if hasattr(chain, "func"):
+            return str(chain.func.__class__.__name__)
+        return str(getattr(chain, "__name__", chain.__class__.__name__))
+
+    async def _process_event(
+        self,
+        event_object: UpdateUnion,
+        data: dict[str, Any],
+    ) -> None:
+        """
+        Endpoint глобальной middleware-цепочки: диспатчит событие
+        по роутерам.
+
+        Args:
+            event_object (UpdateUnion): Событие.
+            data (dict): Данные от middleware-цепочки,
+                содержащие ``_memory_context``, ``_current_state``
+                и ``_process_info``.
+        """
+        memory_context = data["_memory_context"]
+        data["context"] = memory_context
+
+        router_id, is_handled = await self._iter_and_dispatch_routers(
+            event_object=event_object,
+            data=data,
+            memory_context=memory_context,
+            current_state=data["_current_state"],
+            process_info=data["_process_info"],
+        )
+        data["_router_id"] = router_id
+        data["_is_handled"] = is_handled
 
     async def handle(self, event_object: UpdateUnion) -> None:
         """
@@ -662,97 +916,24 @@ class Dispatcher(BotMixin):
             ids = event_object.get_ids()
             memory_context = self.__get_context(*ids)
             current_state = await memory_context.get_state()
-            kwargs = {"context": memory_context}
 
             process_info = (
                 f"{event_object.update_type} | "
                 f"chat_id: {ids[0]}, user_id: {ids[1]}"
             )
 
-            is_handled = False
+            kwargs: dict[str, Any] = {
+                "context": memory_context,
+                "_memory_context": memory_context,
+                "_current_state": current_state,
+                "_process_info": process_info,
+            }
 
-            async def _process_event(
-                _: UpdateUnion, data: dict[str, Any]
-            ) -> None:
-                nonlocal router_id, is_handled, memory_context, current_state
-
-                data["context"] = memory_context
-
-                for index, (
-                    router,
-                    router_middlewares,
-                    router_filters,
-                    router_base_filters,
-                ) in enumerate(self._iter_unique_routers(self.routers)):
-                    if is_handled:
-                        break
-
-                    router_id = router.router_id or index
-
-                    router_filter_result = await self._check_router_filters(
-                        event_object, router_filters, router_base_filters
-                    )
-
-                    if router_filter_result is False:
-                        continue
-
-                    if isinstance(router_filter_result, dict):
-                        data.update(router_filter_result)
-
-                    matching_handlers = self._find_matching_handlers(
-                        router, event_object.update_type
-                    )
-
-                    if not matching_handlers:
-                        continue
-
-                    async def _process_handlers(
-                        event: UpdateUnion, handler_data: dict[str, Any]
-                    ) -> None:
-                        nonlocal is_handled
-
-                        for handler in matching_handlers:
-                            handler_match_result = (
-                                await self._check_handler_match(
-                                    handler, event, current_state
-                                )
-                            )
-
-                            if handler_match_result is False:
-                                continue
-
-                            if isinstance(handler_match_result, dict):
-                                handler_data.update(handler_match_result)
-
-                            await self._execute_handler(
-                                handler=handler,
-                                event=event,
-                                data=handler_data,
-                                handler_middlewares=handler.middlewares,
-                                memory_context=memory_context,
-                                current_state=current_state,
-                                router_id=router_id,
-                                process_info=process_info,
-                            )
-
-                            logger_dp.info(
-                                f"Обработано: "
-                                f"router_id: {router_id} | {process_info}"
-                            )
-
-                            is_handled = True
-                            break
-
-                    if router_middlewares:
-                        router_chain = self.build_middleware_chain(
-                            router_middlewares, _process_handlers
-                        )
-                        await router_chain(event_object, data)
-                    else:
-                        await _process_handlers(event_object, data)
-
-            global_chain = self.build_middleware_chain(
-                self.middlewares, _process_event
+            global_chain = (
+                self._global_mw_chain
+                or self.build_middleware_chain(
+                    self.middlewares, self._process_event
+                )
             )
 
             try:
@@ -760,18 +941,9 @@ class Dispatcher(BotMixin):
             except Exception as e:
                 mem_data = await memory_context.get_data()
 
-                if hasattr(global_chain, "func"):
-                    middleware_title = global_chain.func.__class__.__name__
-                else:
-                    middleware_title = getattr(
-                        global_chain,
-                        "__name__",
-                        global_chain.__class__.__name__,
-                    )
-
                 raise MiddlewareException(
-                    middleware_title=middleware_title,
-                    router_id=router_id,
+                    middleware_title=self._get_middleware_title(global_chain),
+                    router_id=kwargs.get("_router_id", router_id),
                     process_info=process_info,
                     memory_context={
                         "data": mem_data,
@@ -779,6 +951,9 @@ class Dispatcher(BotMixin):
                     },
                     cause=e,
                 ) from e
+
+            router_id = kwargs.get("_router_id")
+            is_handled = kwargs.get("_is_handled", False)
 
             if not is_handled:
                 logger_dp.info(
@@ -791,6 +966,87 @@ class Dispatcher(BotMixin):
                 f"{router_id} | {process_info} | {e} "
             )
 
+    async def _fetch_updates_once(self, bot: Bot) -> dict | None:
+        """
+        Делает один запрос get_updates.
+
+        Returns:
+            dict | None: словарь событий или None при recoverable-ошибке.
+
+        Raises:
+            InvalidToken: при неверном токене бота.
+        """
+        try:
+            return await bot.get_updates(marker=bot.marker_updates)
+        except AsyncioTimeoutError:
+            return None
+        except (MaxConnection, ClientConnectorError) as e:
+            logger_dp.warning(
+                f"Ошибка подключения при получении обновлений: {e}, "
+                f"жду {CONNECTION_RETRY_DELAY} секунд"
+            )
+            await asyncio.sleep(CONNECTION_RETRY_DELAY)
+            return None
+        except InvalidToken:
+            logger_dp.error("Неверный токен! Останавливаю polling")
+            self.polling = False
+            raise
+        except MaxApiError as e:
+            logger_dp.info(
+                f"Ошибка при получении обновлений: {e}, "
+                f"жду {GET_UPDATES_RETRY_DELAY} секунд"
+            )
+            await asyncio.sleep(GET_UPDATES_RETRY_DELAY)
+            return None
+        except Exception as e:
+            logger_dp.error(
+                f"Неожиданная ошибка при получении обновлений: "
+                f"{e.__class__.__name__}: {e}"
+            )
+            await asyncio.sleep(GET_UPDATES_RETRY_DELAY)
+            return None
+
+    async def _dispatch_fetched_events(
+        self,
+        events: dict,
+        current_timestamp: int,
+        *,
+        skip_updates: bool,
+    ) -> None:
+        """Обрабатывает полученные от API события."""
+        try:
+            bot = self._ensure_bot()
+            bot.marker_updates = events.get("marker")
+
+            processed_events = await process_update_request(
+                events=events, bot=bot
+            )
+
+            for event in processed_events:
+                if skip_updates and event.timestamp < current_timestamp:
+                    logger_dp.info(
+                        f"Пропуск события от {from_ms(event.timestamp)}: "
+                        f"{event.update_type}"
+                    )
+                    continue
+
+                if self.use_create_task:
+                    task = asyncio.create_task(self.handle(event))
+                    self._background_tasks.add(task)
+                    task.add_done_callback(self._background_tasks.discard)
+                else:
+                    await self.handle(event)
+
+        except ClientConnectorError:
+            logger_dp.error(
+                f"Ошибка подключения, жду {CONNECTION_RETRY_DELAY} секунд"
+            )
+            await asyncio.sleep(CONNECTION_RETRY_DELAY)
+        except Exception as e:
+            logger_dp.error(
+                f"Общая ошибка при обработке событий: {e.__class__} - {e}"
+            )
+
     async def start_polling(
         self, bot: Bot, *, skip_updates: bool = False
     ) -> None:
@@ -801,7 +1057,6 @@ class Dispatcher(BotMixin):
             bot (Bot): Экземпляр бота.
             skip_updates (bool): Флаг, отвечающий за обработку старых событий.
         """
-
         self.polling = True
 
         await self.__ready(bot)
@@ -809,79 +1064,33 @@ class Dispatcher(BotMixin):
         current_timestamp = to_ms(datetime.now())
 
         while self.polling:
-            try:
-                events: dict = await self._ensure_bot().get_updates(
-                    marker=self._ensure_bot().marker_updates
-                )
-            except AsyncioTimeoutError:
+            events = await self._fetch_updates_once(bot)
+            if events is None:
                 continue
-            except (MaxConnection, ClientConnectorError) as e:
-                logger_dp.warning(
-                    f"Ошибка подключения при получении обновлений: {e}, "
-                    f"жду {CONNECTION_RETRY_DELAY} секунд"
-                )
-                await asyncio.sleep(CONNECTION_RETRY_DELAY)
-                continue
-            except InvalidToken:
-                logger_dp.error("Неверный токен! Останавливаю polling")
-                self.polling = False
-                raise
-            except MaxApiError as e:
-                logger_dp.info(
-                    f"Ошибка при получении обновлений: {e}, "
-                    f"жду {GET_UPDATES_RETRY_DELAY} секунд"
-                )
-                await asyncio.sleep(GET_UPDATES_RETRY_DELAY)
-                continue
-            except Exception as e:
-                logger_dp.error(
-                    f"Неожиданная ошибка при получении обновлений: "
-                    f"{e.__class__.__name__}: {e}"
-                )
-                await asyncio.sleep(GET_UPDATES_RETRY_DELAY)
-                continue
-
-            try:
-                self._ensure_bot().marker_updates = events.get("marker")
-
-                processed_events = await process_update_request(
-                    events=events, bot=self._ensure_bot()
-                )
-
-                for event in processed_events:
-                    if skip_updates and event.timestamp < current_timestamp:
-                        logger_dp.info(
-                            f"Пропуск события от {from_ms(event.timestamp)}: "
-                            f"{event.update_type}"
-                        )
-                        continue
-
-                    if self.use_create_task:
-                        asyncio.create_task(self.handle(event))
-
-                    else:
-                        await self.handle(event)
-
-            except ClientConnectorError:
-                logger_dp.error(
-                    f"Ошибка подключения, жду {CONNECTION_RETRY_DELAY} секунд"
-                )
-                await asyncio.sleep(CONNECTION_RETRY_DELAY)
-            except Exception as e:
-                logger_dp.error(
-                    f"Общая ошибка при обработке событий: {e.__class__} - {e}"
-                )
+            await self._dispatch_fetched_events(
+                events, current_timestamp, skip_updates=skip_updates
+            )
 
     async def stop_polling(self) -> None:
         """
         Останавливает цикл получения обновлений (long polling).
 
-        Этот метод устанавливает флаг polling в False, что приводит к
-        завершению цикла в методе start_polling.
+        Дожидается завершения всех фоновых задач (use_create_task=True),
+        запущенных до момента остановки.
         """
         if self.polling:
             self.polling = False
             logger_dp.info("Polling остановлен")
+
+        if self._background_tasks:
+            logger_dp.info(
+                f"Ожидаю завершения {len(self._background_tasks)} "
+                f"фоновых задач..."
+            )
+            await asyncio.gather(
+                *self._background_tasks, return_exceptions=True
+            )
+            logger_dp.info("Все фоновые задачи завершены")
 
     async def startup(self, bot: Bot) -> None:
         """

--- a/maxapi/filters/__init__.py
+++ b/maxapi/filters/__init__.py
@@ -12,6 +12,7 @@ __all__ = [
     "Contact",
     "ContactFilter",
     "F",
+    "filter_attrs",
 ]
 
 

--- a/maxapi/filters/handler.py
+++ b/maxapi/filters/handler.py
@@ -37,17 +37,20 @@ class Handler:
 
         self.func_event: Callable = func_event
         self.update_type: UpdateType = update_type
-        self.filters: list[MagicFilter] | None = []
-        self.base_filters: list[BaseFilter] | None = []
+        self.filters: list[MagicFilter] = []
+        self.base_filters: list[BaseFilter] = []
 
         states_kwargs = kwargs.pop("states", [])
-        self.states: list[State | None] | None
+        self.states: list[State | None]
         if isinstance(states_kwargs, (list, tuple, set)):
             self.states = list(states_kwargs)
         else:
             self.states = [states_kwargs]
 
         self.middlewares: list[BaseMiddleware] = []
+
+        self.func_args: frozenset[str] | None = None
+        self.mw_chain: Callable | None = None
 
         for arg in args:
             if isinstance(arg, MagicFilter):

--- a/maxapi/utils/updates.py
+++ b/maxapi/utils/updates.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from ..enums.chat_type import ChatType
 from ..types.updates.bot_added import BotAdded
@@ -21,107 +21,102 @@ from ..types.updates.user_removed import UserRemoved
 
 if TYPE_CHECKING:
     from ..bot import Bot
+    from ..types.updates import UpdateUnion
+
+_EVENTS_WITH_USER_ATTR = (
+    UserAdded,
+    BotAdded,
+    BotRemoved,
+    BotStarted,
+    BotStopped,
+    ChatTitleChanged,
+    DialogCleared,
+    DialogMuted,
+    DialogUnmuted,
+    DialogRemoved,
+)
 
 
-async def enrich_event(event_object: Any, bot: Bot) -> Any:
+async def _resolve_chat(event: UpdateUnion, bot: Bot) -> None:
+    """Загружает объект чата для события."""
+
+    if isinstance(event, (DialogRemoved, BotRemoved)):
+        return
+
+    chat_id = getattr(event, "chat_id", None)
+
+    if chat_id is None and isinstance(event, (MessageCreated, MessageEdited)):
+        chat_id = event.message.recipient.chat_id
+
+    elif chat_id is None and isinstance(event, MessageCallback):
+        message = event.message
+        if message is not None:
+            chat_id = message.recipient.chat_id
+
+    if chat_id is not None:
+        event.chat = await bot.get_chat_by_id(chat_id)
+
+
+async def _resolve_from_user(event: UpdateUnion, bot: Bot) -> None:
+    """Определяет отправителя события."""
+
+    if isinstance(event, (MessageCreated, MessageEdited)):
+        event.from_user = getattr(event.message, "sender", None)
+
+    elif isinstance(event, MessageCallback):
+        event.from_user = getattr(event.callback, "user", None)
+
+    elif isinstance(event, MessageRemoved):
+        if event.chat and event.chat.type == ChatType.CHAT:
+            event.from_user = await bot.get_chat_member(
+                chat_id=event.chat_id, user_id=event.user_id
+            )
+        elif event.chat and event.chat.type == ChatType.DIALOG:
+            event.from_user = event.chat
+
+    elif isinstance(event, UserRemoved):
+        if event.admin_id:
+            event.from_user = await bot.get_chat_member(
+                chat_id=event.chat_id, user_id=event.admin_id
+            )
+
+    elif isinstance(event, _EVENTS_WITH_USER_ATTR):
+        event.from_user = event.user
+
+
+def _inject_bot(event: UpdateUnion, bot: Bot) -> None:
+    """Внедряет ссылку на бота в событие, сообщение и вложения."""
+
+    if isinstance(event, (MessageCreated, MessageEdited, MessageCallback)):
+        message = event.message
+        if message is not None:
+            message.bot = bot
+            if message.body is not None:
+                for att in message.body.attachments or []:
+                    if hasattr(att, "bot"):
+                        att.bot = bot
+
+    if hasattr(event, "bot"):
+        event.bot = bot
+
+
+async def enrich_event(event_object: UpdateUnion, bot: Bot) -> UpdateUnion:
     """
     Дополняет объект события данными чата, пользователя и ссылкой на бота.
 
     Args:
-        event_object (Any): Событие, которое нужно дополнить.
+        event_object (UpdateUnion): Событие, которое нужно дополнить.
         bot (Bot): Экземпляр бота.
 
     Returns:
-        Any: Обновлённый объект события.
+        UpdateUnion: Обновлённый объект события.
     """
 
     if not bot.auto_requests:
         return event_object
 
-    # Определяем заранее: чат недоступен (удалён или бот убран из канала)
-    is_chat_unavailable = isinstance(event_object, DialogRemoved) or (
-        isinstance(event_object, BotRemoved)
-        and getattr(event_object, "is_channel", False)
-    )
-
-    if hasattr(event_object, "chat_id"):
-        # Если чат недоступен — не пытаемся его получить
-        if not is_chat_unavailable:
-            event_object.chat = await bot.get_chat_by_id(event_object.chat_id)
-        else:
-            event_object.chat = None
-
-    if isinstance(event_object, (MessageCreated, MessageEdited)):
-        recipient = event_object.message.recipient
-        if recipient.chat_id is not None and event_object.chat is None:
-            event_object.chat = await bot.get_chat_by_id(recipient.chat_id)
-
-        event_object.from_user = getattr(event_object.message, "sender", None)
-
-    elif isinstance(event_object, MessageCallback):
-        message = event_object.message
-        if message is not None and message.recipient.chat_id is not None:
-            chat_id = message.recipient.chat_id
-            if event_object.chat is None:
-                event_object.chat = await bot.get_chat_by_id(chat_id)
-
-        event_object.from_user = getattr(event_object.callback, "user", None)
-
-    elif isinstance(event_object, MessageRemoved):
-        if event_object.chat is None:
-            event_object.chat = await bot.get_chat_by_id(event_object.chat_id)
-
-        if event_object.chat and event_object.chat.type == ChatType.CHAT:
-            event_object.from_user = await bot.get_chat_member(
-                chat_id=event_object.chat_id, user_id=event_object.user_id
-            )
-
-        elif event_object.chat and event_object.chat.type == ChatType.DIALOG:
-            event_object.from_user = event_object.chat
-
-    elif isinstance(event_object, UserRemoved):
-        if event_object.chat is None:
-            event_object.chat = await bot.get_chat_by_id(event_object.chat_id)
-        if event_object.admin_id:
-            event_object.from_user = await bot.get_chat_member(
-                chat_id=event_object.chat_id, user_id=event_object.admin_id
-            )
-
-    elif isinstance(
-        event_object,
-        (
-            UserAdded,
-            BotAdded,
-            BotRemoved,
-            BotStarted,
-            ChatTitleChanged,
-            BotStopped,
-            DialogCleared,
-            DialogMuted,
-            DialogUnmuted,
-        ),
-    ):
-        if event_object.chat is None and not is_chat_unavailable:
-            event_object.chat = await bot.get_chat_by_id(event_object.chat_id)
-        event_object.from_user = event_object.user
-
-    elif isinstance(event_object, DialogRemoved):
-        # Чат уже удалён — получить его невозможно
-        event_object.from_user = event_object.user
-
-    if isinstance(
-        event_object, (MessageCreated, MessageEdited, MessageCallback)
-    ):
-        object_message = event_object.message
-
-        if object_message is not None:
-            object_message.bot = bot
-            if object_message.body is not None:
-                for att in object_message.body.attachments or []:
-                    if hasattr(att, "bot"):
-                        att.bot = bot
-
-    if hasattr(event_object, "bot"):
-        event_object.bot = bot
+    await _resolve_chat(event_object, bot)
+    await _resolve_from_user(event_object, bot)
+    _inject_bot(event_object, bot)
 
     return event_object

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,7 @@ dev = [
     "fastapi>=0.103.0,<1",
     "uvicorn>=0.15.0,<1",
     "litestar>=2.0.0,<3",
+    "aresponses>=3.0.0,<4",
 ]
 
 [tool.uv]
@@ -122,7 +123,6 @@ target-version = "py310"
 select = ["ALL"]
 ignore = [
     "BLE", # TODO: требует рефакторинга
-    "G004", # TODO: требует рефакторинга
     "ERA", # TODO: требует рефакторинга
     "N", # TODO: требует рефакторинга
     "PGH", # TODO: требует рефакторинга
@@ -161,13 +161,6 @@ flake8-type-checking.runtime-evaluated-base-classes = [
     "PL",
     "S",
     "SLF",
-]
-"dispatcher.py" = [
-    "B023", # TODO: требует рефакторинга dispatcher
-    "C90", # TODO: требует рефакторинга dispatcher
-]
-"maxapi/utils/updates.py" = [
-    "C90", # TODO: требует рефакторинга
 ]
 "maxapi/methods/send_message.py" = [
     "C90", # TODO: требует рефакторинга

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -1,5 +1,7 @@
 """Тесты для Dispatcher и Router."""
 
+import asyncio
+import logging
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
@@ -12,6 +14,8 @@ from maxapi.filters.command import Command, CommandsInfo
 from maxapi.filters.handler import Handler
 from maxapi.types.updates.bot_started import BotStarted
 from maxapi.types.updates.message_created import MessageCreated
+
+logger = logging.getLogger(__name__)
 
 
 class TestDispatcherInitialization:
@@ -72,8 +76,8 @@ class TestDispatcherHandlers:
         """Тест регистрации обработчика message_created."""
 
         @dispatcher.message_created()
-        async def _(event: MessageCreated):
-            pass
+        async def _handler(event: MessageCreated):
+            logger.debug("Получено событие: %s", event)
 
         assert len(dispatcher.event_handlers) == 1
         handler = dispatcher.event_handlers[0]
@@ -83,12 +87,12 @@ class TestDispatcherHandlers:
         """Тест регистрации нескольких обработчиков."""
 
         @dispatcher.message_created()
-        async def handler1(event: MessageCreated):
-            pass
+        async def _handler1(event: MessageCreated):
+            logger.debug("Получено событие: %s", event)
 
         @dispatcher.bot_started()
-        async def handler2(event: BotStarted):
-            pass
+        async def _handler2(event: BotStarted):
+            logger.debug("Получено событие: %s", event)
 
         assert len(dispatcher.event_handlers) == 2
 
@@ -96,8 +100,8 @@ class TestDispatcherHandlers:
         """Тест регистрации обработчика с фильтром."""
 
         @dispatcher.message_created(F.text == "test")
-        async def _(event: MessageCreated):
-            pass
+        async def _handler(event: MessageCreated):
+            logger.debug("Получено событие: %s", event)
 
         assert len(dispatcher.event_handlers) == 1
         handler = dispatcher.event_handlers[0]
@@ -107,8 +111,8 @@ class TestDispatcherHandlers:
         """Тест регистрации обработчика on_started."""
 
         @dispatcher.on_started()
-        async def on_started():
-            pass
+        async def _on_started():
+            logger.debug("Бот запущен")
 
         assert dispatcher.on_started_func is not None
 
@@ -209,8 +213,8 @@ class TestDispatcherRouters:
         router = Router(router_id="test_router")
 
         @router.message_created()
-        async def handler(event: MessageCreated):
-            pass
+        async def _handler(event: MessageCreated):
+            logger.debug("Получено событие: %s", event)
 
         dispatcher.include_routers(router)
         assert len(router.event_handlers) == 1
@@ -263,6 +267,7 @@ class TestDispatcherFilters:
 
         class TestFilter(BaseFilter):
             async def __call__(self, event):
+                logger.debug("Получено событие: %s", event)
                 return True
 
         filter_obj = TestFilter()
@@ -321,7 +326,9 @@ class TestDispatcherMiddlewareChain:
                 call_order.append(2)
                 return await handler(event, data)
 
-        async def handler(event, data):
+        async def _handler(event, data):
+            logger.debug("Получено событие: %s и данные %s", event, data)
+            await asyncio.sleep(0)
             call_order.append(3)
             return "result"
 
@@ -329,7 +336,7 @@ class TestDispatcherMiddlewareChain:
         middleware2 = Middleware2()
 
         chain = dispatcher.build_middleware_chain(
-            [middleware1, middleware2], handler
+            [middleware1, middleware2], _handler
         )
 
         # Проверяем, что цепочка создана
@@ -356,7 +363,7 @@ class TestDispatcherAsync:
 
             await dispatcher.check_me()
 
-            assert bot._me == mock_me
+            assert bot.me == mock_me
             mock_get_me.assert_called_once()
 
     async def test_process_base_filters(
@@ -368,6 +375,7 @@ class TestDispatcherAsync:
 
         class TestFilter(BaseFilter):
             async def __call__(self, event):
+                logger.debug("Получено событие: %s", event)
                 return {"test_key": "test_value"}
 
         filter_obj = TestFilter()
@@ -389,6 +397,7 @@ class TestDispatcherAsync:
 
         class TestFilter(BaseFilter):
             async def __call__(self, event):
+                logger.debug("Получено событие: %s", event)
                 return False
 
         filter_obj = TestFilter()
@@ -398,7 +407,7 @@ class TestDispatcherAsync:
             sample_message_created_event, dispatcher.base_filters
         )
 
-        assert result is False
+        assert result is None
 
 
 class TestDispatcherSubscriptions:
@@ -496,3 +505,907 @@ class TestDispatcherReady:
         dispatcher.check_me.assert_called()
         dispatcher._prepare_handlers.assert_called_once_with(bot)
         assert dispatcher in dispatcher.routers
+
+
+# ===========================================================================
+# Helpers
+# ===========================================================================
+
+
+def _setup_for_handle(dispatcher: Dispatcher, bot: Bot) -> None:
+    """Настраивает dispatcher для тестирования полного dispatch-пайплайна."""
+    dispatcher.routers.append(dispatcher)
+    dispatcher._prepare_handlers(bot)
+    dispatcher._global_mw_chain = dispatcher.build_middleware_chain(
+        dispatcher.middlewares, dispatcher._process_event
+    )
+
+
+# ===========================================================================
+# Полный пайплайн handle → роутеры → обработчик
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+class TestHandlePipeline:
+    """Тесты полного пайплайна dispatch."""
+
+    async def test_handle_dispatches_to_matching_handler(
+        self, dispatcher, bot, fixture_message_created
+    ):
+        """handle() находит и вызывает подходящий обработчик."""
+        handled = []
+
+        @dispatcher.message_created()
+        async def _handler(event: MessageCreated):
+            logger.debug("Получено событие: %s", event)
+            handled.append(event)
+
+        _setup_for_handle(dispatcher, bot)
+        await dispatcher.handle(fixture_message_created)
+
+        assert len(handled) == 1
+        assert handled[0] is fixture_message_created
+
+    async def test_handle_no_matching_handler_logs_ignored(
+        self, dispatcher, bot, fixture_message_created
+    ):
+        """
+        handle() завершается без ошибки, если нет
+        подходящего обработчика.
+        """
+        _setup_for_handle(dispatcher, bot)
+        await dispatcher.handle(fixture_message_created)  # не должно падать
+
+    async def test_handle_handler_state_mismatch_skips_and_returns_false(
+        self, dispatcher, bot, fixture_message_created
+    ):
+        """Если handler не подходит по state, он пропускается (continue),
+        и _run_router_handlers возвращает False."""
+
+        class MyState:
+            pass
+
+        required_state = MyState()
+
+        @dispatcher.message_created()
+        async def _handler(event: MessageCreated):
+            logger.debug("Получено событие: %s", event)
+
+        # Назначаем состояние, которое не совпадёт (current_state = None)
+        dispatcher.event_handlers[-1].states = [required_state]
+
+        _setup_for_handle(dispatcher, bot)
+        await dispatcher.handle(fixture_message_created)  # не должно падать
+
+    async def test_handle_catches_handler_exception(
+        self, dispatcher, bot, fixture_message_created
+    ):
+        """handle() перехватывает исключение обработчика и логирует."""
+
+        @dispatcher.message_created()
+        async def _handler(event: MessageCreated):
+            raise RuntimeError("ошибка обработчика")
+
+        _setup_for_handle(dispatcher, bot)
+        await dispatcher.handle(fixture_message_created)  # не должно всплывать
+
+    async def test_handle_catches_middleware_exception(
+        self, dispatcher, bot, fixture_message_created
+    ):
+        """
+        handle() перехватывает MiddlewareException
+        из глобального middleware.
+        """
+        from maxapi.filters.middleware import BaseMiddleware
+
+        class FailingMiddleware(BaseMiddleware):
+            async def __call__(self, handler, event, data):
+                raise RuntimeError("сбой middleware")
+
+        dispatcher.middleware(FailingMiddleware())
+        _setup_for_handle(dispatcher, bot)
+        await dispatcher.handle(fixture_message_created)  # не должно всплывать
+
+
+# ===========================================================================
+# Вспомогательные методы dispatcher
+# ===========================================================================
+
+
+class TestDispatcherHelpers:
+    """Тесты вспомогательных методов Dispatcher."""
+
+    def test_lru_context_move_to_end(self, dispatcher):
+        """Повторный доступ к контексту перемещает его в конец (LRU hit)."""
+        dispatcher._Dispatcher__get_context(1, 1)
+        dispatcher._Dispatcher__get_context(2, 2)
+
+        # Обращаемся к (1,1) — должен переместиться в конец
+        dispatcher._Dispatcher__get_context(1, 1)
+
+        keys = list(dispatcher.contexts.keys())
+        assert keys[-1] == (1, 1)
+
+    def test_lru_context_evicts_oldest_when_full(self, dispatcher):
+        """Когда кеш переполнен, самый старый контекст вытесняется."""
+        import maxapi.dispatcher as dp_module
+
+        original = dp_module.CONTEXTS_MAX_SIZE
+        dp_module.CONTEXTS_MAX_SIZE = 2
+        try:
+            dispatcher._Dispatcher__get_context(1, 1)
+            dispatcher._Dispatcher__get_context(2, 2)
+            # Третий вызов должен вытеснить (1, 1)
+            dispatcher._Dispatcher__get_context(3, 3)
+            assert (1, 1) not in dispatcher.contexts
+            assert len(dispatcher.contexts) == 2
+        finally:
+            dp_module.CONTEXTS_MAX_SIZE = original
+
+    def test_find_matching_handlers_without_index(self, dispatcher):
+        """Fallback на линейный поиск когда handlers_by_type не построен."""
+        router = Router(router_id="r1")
+
+        @router.message_created()
+        async def _handler(event: MessageCreated):
+            logger.debug("Получено событие: %s", event)
+
+        router.handlers_by_type = None  # индекс не построен
+
+        result = dispatcher._find_matching_handlers(
+            router, UpdateType.MESSAGE_CREATED
+        )
+        assert len(result) == 1
+
+    async def test_check_handler_match_state_mismatch(
+        self, dispatcher, fixture_message_created
+    ):
+        """Возвращает None когда текущее состояние не совпадает."""
+
+        class State:
+            pass
+
+        state_a, state_b = State(), State()
+        handler = Handler(
+            func_event=lambda e: None,
+            update_type=UpdateType.MESSAGE_CREATED,
+        )
+        handler.states = [state_a]
+
+        result = await dispatcher._check_handler_match(
+            handler=handler,
+            event=fixture_message_created,
+            current_state=state_b,
+        )
+        assert result is None
+
+    def test_get_middleware_title_with_func_attr(self, dispatcher):
+        """_get_middleware_title берёт имя из chain.func.__class__.__name__."""
+        import functools
+
+        from maxapi.filters.middleware import BaseMiddleware
+
+        class MyMiddleware(BaseMiddleware):
+            async def __call__(self, handler, event, data):
+                return await handler(event, data)
+
+        partial_chain = functools.partial(MyMiddleware(), None)
+        title = dispatcher._get_middleware_title(partial_chain)
+        assert "MyMiddleware" in title
+
+    def test_get_middleware_title_without_func_attr(self, dispatcher):
+        """_get_middleware_title берёт __name__ когда нет .func."""
+
+        async def my_handler(event, data):
+            await asyncio.sleep(0)
+
+        title = dispatcher._get_middleware_title(my_handler)
+        assert "my_handler" in title
+
+
+# ===========================================================================
+# _execute_handler — обёртка исключения
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+class TestExecuteHandler:
+    async def test_execute_handler_wraps_exception_in_handler_exception(
+        self, dispatcher, fixture_message_created
+    ):
+        """_execute_handler оборачивает RuntimeError в HandlerException."""
+        from maxapi.exceptions.dispatcher import HandlerException
+
+        async def _failing(event):
+            raise ValueError("тест")
+
+        handler = Handler(
+            func_event=_failing,
+            update_type=UpdateType.MESSAGE_CREATED,
+        )
+        handler.func_args = frozenset()
+        handler.mw_chain = None
+
+        memory_context = dispatcher._Dispatcher__get_context(1, 2)
+
+        with pytest.raises(HandlerException):
+            await dispatcher._execute_handler(
+                handler=handler,
+                event=fixture_message_created,
+                data={},
+                handler_middlewares=[],
+                memory_context=memory_context,
+                current_state=None,
+                router_id="test",
+                process_info="test",
+            )
+
+
+# ===========================================================================
+# stop_polling
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+class TestStopPolling:
+    async def test_stop_polling_sets_polling_false(self, dispatcher):
+        dispatcher.polling = True
+        await dispatcher.stop_polling()
+        assert dispatcher.polling is False
+
+    async def test_stop_polling_already_stopped_no_error(self, dispatcher):
+        dispatcher.polling = False
+        await dispatcher.stop_polling()  # не должно падать
+
+    async def test_stop_polling_waits_for_background_tasks(self, dispatcher):
+        """stop_polling дожидается завершения фоновых задач."""
+        completed = []
+
+        async def _work():
+            await asyncio.sleep(0)
+            completed.append(1)
+
+        dispatcher.polling = True
+        task = asyncio.create_task(_work())
+        dispatcher._background_tasks.add(task)
+        task.add_done_callback(dispatcher._background_tasks.discard)
+
+        await dispatcher.stop_polling()
+
+        assert completed == [1]
+        assert len(dispatcher._background_tasks) == 0
+
+
+# ===========================================================================
+# handle_raw_response — перехват исключений
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+class TestHandleRawResponse:
+    async def test_handle_raw_response_catches_handler_exception(
+        self, dispatcher, bot
+    ):
+        """handle_raw_response не всплывает при ошибке обработчика."""
+        dispatcher.bot = bot
+
+        async def _failing(event):
+            raise RuntimeError("raw error")
+
+        handler = Handler(
+            func_event=_failing,
+            update_type=UpdateType.RAW_API_RESPONSE,
+        )
+        dispatcher.event_handlers.append(handler)
+        dispatcher.routers.append(dispatcher)
+        dispatcher._prepare_handlers(bot)
+
+        await dispatcher.handle_raw_response(
+            event_type=UpdateType.RAW_API_RESPONSE,
+            raw_data={"test": "data"},
+        )
+
+
+# ===========================================================================
+# Handler — BaseFilter как позиционный аргумент
+# ===========================================================================
+
+
+class TestHandlerBaseFilterArg:
+    def test_handler_accepts_base_filter_as_positional_arg(self):
+        """Handler принимает BaseFilter позиционным аргументом."""
+        from maxapi.filters.filter import BaseFilter
+
+        class MyFilter(BaseFilter):
+            async def __call__(self, event):
+                logger.debug("Получено событие: %s", event)
+                return True
+
+        filter_obj = MyFilter()
+        handler = Handler(
+            filter_obj,
+            func_event=lambda e: None,
+            update_type=UpdateType.MESSAGE_CREATED,
+        )
+
+        assert filter_obj in handler.base_filters
+
+    def test_handler_accepts_base_middleware_as_positional_arg(self):
+        """Handler принимает BaseMiddleware позиционным аргументом."""
+        from maxapi.filters.middleware import BaseMiddleware
+
+        class MyMiddleware(BaseMiddleware):
+            async def __call__(self, handler, event, data):
+                return await handler(event, data)
+
+        mw = MyMiddleware()
+        handler = Handler(
+            mw,
+            func_event=lambda e: None,
+            update_type=UpdateType.MESSAGE_CREATED,
+        )
+
+        assert mw in handler.middlewares
+
+
+# ===========================================================================
+# _fetch_updates_once — ветки обработки ошибок
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+class TestFetchUpdatesOnce:
+    """Тесты всех веток _fetch_updates_once."""
+
+    async def test_returns_updates_on_success(self, dispatcher, bot):
+        dispatcher.bot = bot
+        bot.get_updates = AsyncMock(return_value={"updates": [], "marker": 1})
+        result = await dispatcher._fetch_updates_once(bot)
+        assert result == {"updates": [], "marker": 1}
+
+    async def test_asyncio_timeout_returns_none(self, dispatcher, bot):
+        from asyncio.exceptions import TimeoutError as AsyncioTimeoutError
+
+        bot.get_updates = AsyncMock(side_effect=AsyncioTimeoutError())
+        result = await dispatcher._fetch_updates_once(bot)
+        assert result is None
+
+    async def test_max_connection_error_returns_none(self, dispatcher, bot):
+        from maxapi.exceptions.max import MaxConnection
+
+        bot.get_updates = AsyncMock(side_effect=MaxConnection("conn error"))
+        with patch("maxapi.dispatcher.CONNECTION_RETRY_DELAY", 0):
+            result = await dispatcher._fetch_updates_once(bot)
+        assert result is None
+
+    async def test_invalid_token_stops_polling(self, dispatcher, bot):
+        from maxapi.exceptions.max import InvalidToken
+
+        bot.get_updates = AsyncMock(side_effect=InvalidToken("bad token"))
+        dispatcher.polling = True
+        with pytest.raises(InvalidToken):
+            await dispatcher._fetch_updates_once(bot)
+        assert dispatcher.polling is False
+
+    async def test_max_api_error_returns_none(self, dispatcher, bot):
+        from maxapi.exceptions.max import MaxApiError
+
+        bot.get_updates = AsyncMock(side_effect=MaxApiError(400, "api error"))
+        with patch("maxapi.dispatcher.GET_UPDATES_RETRY_DELAY", 0):
+            result = await dispatcher._fetch_updates_once(bot)
+        assert result is None
+
+    async def test_generic_exception_returns_none(self, dispatcher, bot):
+        bot.get_updates = AsyncMock(side_effect=RuntimeError("unexpected"))
+        with patch("maxapi.dispatcher.GET_UPDATES_RETRY_DELAY", 0):
+            result = await dispatcher._fetch_updates_once(bot)
+        assert result is None
+
+
+# ===========================================================================
+# _dispatch_fetched_events — обработка полученных событий
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+class TestDispatchFetchedEvents:
+    """Тесты _dispatch_fetched_events."""
+
+    async def test_dispatches_events_sequentially(
+        self, dispatcher, bot, fixture_message_created
+    ):
+        """События обрабатываются последовательно (use_create_task=False)."""
+        handled = []
+
+        @dispatcher.message_created()
+        async def _handler(event: MessageCreated):
+            logger.debug("Получено событие: %s", event)
+            handled.append(event)
+
+        dispatcher.bot = bot
+        _setup_for_handle(dispatcher, bot)
+
+        raw = {"updates": [fixture_message_created.model_dump()], "marker": 1}
+
+        with patch(
+            "maxapi.dispatcher.process_update_request",
+            new=AsyncMock(return_value=[fixture_message_created]),
+        ):
+            await dispatcher._dispatch_fetched_events(
+                events=raw,
+                current_timestamp=0,
+                skip_updates=False,
+            )
+
+        assert len(handled) == 1
+
+    async def test_skips_old_events_when_skip_updates_true(
+        self, dispatcher, bot, fixture_message_created
+    ):
+        """Старые события пропускаются при skip_updates=True."""
+        handled = []
+
+        @dispatcher.message_created()
+        async def _handler(event: MessageCreated):
+            logger.debug("Получено событие: %s", event)
+            handled.append(event)
+
+        dispatcher.bot = bot
+        _setup_for_handle(dispatcher, bot)
+
+        # timestamp события меньше current_timestamp → пропуск
+        future_timestamp = fixture_message_created.timestamp + 1_000_000_000
+
+        with patch(
+            "maxapi.dispatcher.process_update_request",
+            new=AsyncMock(return_value=[fixture_message_created]),
+        ):
+            await dispatcher._dispatch_fetched_events(
+                events={},
+                current_timestamp=future_timestamp,
+                skip_updates=True,
+            )
+
+        assert len(handled) == 0
+
+    async def test_use_create_task_creates_background_task(
+        self, dispatcher, bot, fixture_message_created
+    ):
+        """
+        При use_create_task=True событие обрабатывается
+        через asyncio.Task.
+        """
+        dispatcher.use_create_task = True
+        dispatcher.bot = bot
+        _setup_for_handle(dispatcher, bot)
+
+        with patch(
+            "maxapi.dispatcher.process_update_request",
+            new=AsyncMock(return_value=[fixture_message_created]),
+        ):
+            await dispatcher._dispatch_fetched_events(
+                events={},
+                current_timestamp=0,
+                skip_updates=False,
+            )
+            # Даём задаче и её done-callback завершиться
+            for _ in range(3):
+                await asyncio.sleep(0)
+
+        assert len(dispatcher._background_tasks) == 0  # задача завершена
+
+
+# ===========================================================================
+# call_handler — **data передаётся хендлеру (line 362)
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+class TestCallHandlerWithKwargs:
+    """Покрывает line 362: await handler.func_event(event_object, **data)"""
+
+    async def test_handler_receives_kwargs_from_base_filter(
+        self, dispatcher, bot, fixture_message_created
+    ):
+        """BaseFilter возвращает dict → handler получает kwargs."""
+        from maxapi.filters.filter import BaseFilter
+
+        received: dict = {}
+
+        class DataFilter(BaseFilter):
+            async def __call__(self, event):
+                return {"answer": 42}
+
+        @dispatcher.message_created(DataFilter())
+        async def _h(event: MessageCreated, answer: int):
+            received["answer"] = answer
+
+        _setup_for_handle(dispatcher, bot)
+        await dispatcher.handle(fixture_message_created)
+
+        assert received.get("answer") == 42
+
+
+# ===========================================================================
+# _iter_routers — вложенные роутеры (lines 463-473) и цикл (line 439)
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+class TestIterRoutersNested:
+    """Покрывает lines 463-473: рекурсивный обход sub-роутеров."""
+
+    async def test_nested_sub_router_handler_is_dispatched(
+        self, dispatcher, bot, fixture_message_created
+    ):
+        """Обработчик во вложенном sub-роутере вызывается."""
+        handled = []
+
+        nested = Router(router_id="sub_nested")
+
+        @nested.message_created()
+        async def _h(event: MessageCreated):
+            handled.append(event)
+
+        outer = Router(router_id="sub_outer")
+        outer.include_routers(nested)
+        dispatcher.include_routers(outer)
+
+        _setup_for_handle(dispatcher, bot)
+        await dispatcher.handle(fixture_message_created)
+
+        assert len(handled) == 1
+
+
+class TestIterRoutersCycle:
+    """
+    Покрывает line 439: цикл в графе роутеров
+    обрабатывается без зависания.
+    """
+
+    def test_cycle_detection_does_not_hang(self, dispatcher):
+        r_a = Router(router_id="cycle_a")
+        r_b = Router(router_id="cycle_b")
+        r_a.include_routers(r_b)
+        r_b.include_routers(r_a)  # цикл
+
+        dispatcher.include_routers(r_a)
+
+        result = list(dispatcher._iter_unique_routers(dispatcher.routers))
+        ids = {r.router_id for r, *_ in result}
+        assert "cycle_a" in ids
+        assert "cycle_b" in ids
+
+
+# ===========================================================================
+# _iter_unique_routers — предупреждение о дублях (lines 521-530, 535)
+# ===========================================================================
+
+
+class TestDuplicateRouterWarning:
+    """Покрывает lines 521-530, 535."""
+
+    def test_warns_on_duplicate_inclusion(self, dispatcher, caplog):
+        router = Router(router_id="dup_router")
+        dispatcher.include_routers(router)
+        dispatcher.include_routers(router)  # дубль
+
+        with caplog.at_level("WARNING", logger="maxapi.dispatcher"):
+            list(
+                dispatcher._iter_unique_routers(
+                    dispatcher.routers, warn_duplicates=True
+                )
+            )
+
+        assert any("dup_router" in r.getMessage() for r in caplog.records)
+
+
+# ===========================================================================
+# Фильтры на уровне роутера (lines 560, 563, 851)
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+class TestRouterLevelFilters:
+    async def test_failing_magic_filter_skips_router(
+        self, dispatcher, bot, fixture_message_created
+    ):
+        """Покрывает lines 560, 851: failing MagicFilter → continue."""
+        handled = []
+
+        router = Router(router_id="filtered_router")
+        router.filters.append(F.text == "__NEVER_MATCH__")
+
+        @router.message_created()
+        async def _h(event: MessageCreated):
+            handled.append(event)
+
+        dispatcher.include_routers(router)
+        _setup_for_handle(dispatcher, bot)
+
+        await dispatcher.handle(fixture_message_created)
+
+        assert len(handled) == 0
+
+    async def test_router_base_filter_calls_process_base_filters(
+        self, dispatcher, bot, fixture_message_created
+    ):
+        """
+        Покрывает line 563: process_base_filters
+        вызывается для router.base_filters.
+        """
+        from maxapi.filters.filter import BaseFilter
+
+        enriched: dict = {}
+
+        class RouterBaseFilter(BaseFilter):
+            async def __call__(self, event):
+                return {"router_key": "router_val"}
+
+        router = Router(router_id="base_filter_router")
+        router.base_filters.append(RouterBaseFilter())
+
+        @router.message_created()
+        async def _h(event: MessageCreated, router_key: str = ""):
+            enriched["router_key"] = router_key
+
+        dispatcher.include_routers(router)
+        _setup_for_handle(dispatcher, bot)
+
+        await dispatcher.handle(fixture_message_created)
+
+        assert enriched.get("router_key") == "router_val"
+
+
+# ===========================================================================
+# Middleware на уровне роутера (lines 806-809)
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+class TestRouterMiddlewareChain:
+    """Покрывает lines 806-809."""
+
+    async def test_router_middleware_wraps_dispatch(
+        self, dispatcher, bot, fixture_message_created
+    ):
+        from maxapi.filters.middleware import BaseMiddleware
+
+        calls: list = []
+
+        class RouterMW(BaseMiddleware):
+            async def __call__(self, handler, event, data):
+                calls.append("mw")
+                return await handler(event, data)
+
+        router = Router(router_id="mw_router")
+        router.middlewares.append(RouterMW())
+
+        @router.message_created()
+        async def _h(event: MessageCreated):
+            calls.append("handler")
+
+        dispatcher.include_routers(router)
+        _setup_for_handle(dispatcher, bot)
+
+        await dispatcher.handle(fixture_message_created)
+
+        assert "mw" in calls
+        assert "handler" in calls
+
+
+# ===========================================================================
+# ClientConnectorError в _dispatch_fetched_events (lines 1052-1058)
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+class TestDispatchFetchedEventsConnectorError:
+    """Покрывает lines 1052-1058."""
+
+    async def test_client_connector_error_caught_and_logged(
+        self, dispatcher, bot
+    ):
+        from unittest.mock import Mock
+
+        from aiohttp import ClientConnectorError
+
+        dispatcher.bot = bot
+        _setup_for_handle(dispatcher, bot)
+
+        err = ClientConnectorError(Mock(), ConnectionRefusedError("refused"))
+
+        with (
+            patch(
+                "maxapi.dispatcher.process_update_request",
+                new=AsyncMock(side_effect=err),
+            ),
+            patch("maxapi.dispatcher.CONNECTION_RETRY_DELAY", 0),
+        ):
+            await dispatcher._dispatch_fetched_events(
+                events={"updates": [], "marker": 0},
+                current_timestamp=0,
+                skip_updates=False,
+            )  # не должно всплывать
+
+    async def test_generic_exception_caught_and_logged(self, dispatcher, bot):
+        """
+        Покрывает lines 1057-1058: generic Exception
+        в _dispatch_fetched_events.
+        """
+        dispatcher.bot = bot
+        _setup_for_handle(dispatcher, bot)
+
+        with patch(
+            "maxapi.dispatcher.process_update_request",
+            new=AsyncMock(
+                side_effect=RuntimeError("unexpected dispatch error")
+            ),
+        ):
+            await dispatcher._dispatch_fetched_events(
+                events={"updates": [], "marker": 0},
+                current_timestamp=0,
+                skip_updates=False,
+            )  # не должно всплывать
+
+
+# ===========================================================================
+# start_polling — полный HTTP-цикл через aresponses (lines 1072-1082)
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+class TestStartPollingWithAresponses:
+    """
+    Покрывает lines 1072-1082 через реальную сетевую эмуляцию (aresponses).
+
+    aresponses перехватывает TCP-соединения на уровне резолвера и
+    перенаправляет их на локальный mock-сервер — никакого реального
+    подключения к platform-api.max.ru не происходит.
+    """
+
+    async def test_start_polling_calls_http_endpoints_and_stops(
+        self, aresponses
+    ):
+        """
+        Проверяет, что start_polling:
+          1. обращается к /me (check_me)            ← lines 1072-1074
+          2. первый /updates возвращает 500 → returns None      ← line 1081
+          3. второй /updates возвращает {} → _dispatch вызван   ← line 1082
+        """
+        from aiohttp import web
+        from maxapi.bot import Bot
+        from maxapi.client.default import DefaultConnectionProperties
+
+        bot = Bot(
+            token="polling_test_token",
+            auto_check_subscriptions=False,
+            default_connection=DefaultConnectionProperties(
+                max_retries=0, timeout=5, sock_connect=5
+            ),
+        )
+        dp = Dispatcher()
+
+        # ── Mock GET /me ──────────────────────────────────────────────────
+        aresponses.add(
+            "platform-api.max.ru",
+            "/me",
+            "get",
+            {
+                "user_id": 42,
+                "first_name": "PollingBot",
+                "is_bot": True,
+                "last_activity_time": 1_700_000_000,
+            },
+        )
+
+        # ── Mock GET /updates (1st): 500 → MaxApiError → returns None ────
+        aresponses.add(
+            "platform-api.max.ru",
+            "/updates",
+            "get",
+            web.Response(
+                status=500,
+                text='{"code":500,"message":"test_error"}',
+                content_type="application/json",
+            ),
+        )
+
+        # ── Mock GET /updates (2nd): 200 → events dict → dispatch ────────
+        aresponses.add(
+            "platform-api.max.ru",
+            "/updates",
+            "get",
+            {"updates": [], "marker": 0},
+        )
+
+        # После первого же вызова _dispatch_fetched_events останавливаем цикл
+        async def _stop(events, ts, *, skip_updates):
+            dp.polling = False
+
+        dp._dispatch_fetched_events = _stop
+
+        with patch("maxapi.dispatcher.GET_UPDATES_RETRY_DELAY", 0):
+            await dp.start_polling(bot)
+
+        assert bot.me is not None
+        assert bot.me.user_id == 42
+
+        if bot.session and not bot.session.closed:
+            await bot.session.close()
+
+
+# ===========================================================================
+# startup (line 1119)
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+class TestStartup:
+    """Покрывает line 1119."""
+
+    async def test_startup_calls_ready(self, dispatcher, bot):
+        dispatcher.check_me = AsyncMock()
+        dispatcher._prepare_handlers = Mock()
+
+        await dispatcher.startup(bot)
+
+        assert dispatcher.bot is bot
+        assert bot.dispatcher is dispatcher
+        dispatcher.check_me.assert_called_once()
+        dispatcher._prepare_handlers.assert_called_once_with(bot)
+
+
+# ===========================================================================
+# handle_webhook (lines 1154-1155)
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+class TestHandleWebhook:
+    """Покрывает lines 1154-1155."""
+
+    async def test_handle_webhook_creates_and_runs_instance(
+        self, dispatcher, bot
+    ):
+        mock_wh_instance = Mock()
+        mock_wh_instance.run = AsyncMock()
+        mock_wh_type = Mock(return_value=mock_wh_instance)
+
+        await dispatcher.handle_webhook(
+            bot,
+            host="localhost",
+            port=8080,
+            path="/hook",
+            webhook_type=mock_wh_type,
+        )
+
+        mock_wh_type.assert_called_once_with(
+            dp=dispatcher, bot=bot, secret=None
+        )
+        mock_wh_instance.run.assert_called_once_with(
+            host="localhost", port=8080, path="/hook"
+        )
+
+
+# ===========================================================================
+# Устаревшее событие — DeprecationWarning (line 1240)
+# ===========================================================================
+
+
+class TestDeprecatedEvent:
+    """Покрывает line 1240."""
+
+    def test_deprecated_event_emits_deprecation_warning(self):
+        import warnings
+
+        dp = Dispatcher()
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+
+            @dp.message_chat_created()
+            async def _h(event):
+                pass
+
+        assert any(issubclass(x.category, DeprecationWarning) for x in w)

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -344,7 +344,6 @@ class TestDispatcherMiddlewareChain:
         assert callable(chain)
 
 
-@pytest.mark.asyncio
 class TestDispatcherAsync:
     """Асинхронные тесты Dispatcher."""
 
@@ -526,7 +525,6 @@ def _setup_for_handle(dispatcher: Dispatcher, bot: Bot) -> None:
 # ===========================================================================
 
 
-@pytest.mark.asyncio
 class TestHandlePipeline:
     """Тесты полного пайплайна dispatch."""
 
@@ -709,7 +707,6 @@ class TestDispatcherHelpers:
 # ===========================================================================
 
 
-@pytest.mark.asyncio
 class TestExecuteHandler:
     async def test_execute_handler_wraps_exception_in_handler_exception(
         self, dispatcher, fixture_message_created
@@ -747,7 +744,6 @@ class TestExecuteHandler:
 # ===========================================================================
 
 
-@pytest.mark.asyncio
 class TestStopPolling:
     async def test_stop_polling_sets_polling_false(self, dispatcher):
         dispatcher.polling = True
@@ -782,7 +778,6 @@ class TestStopPolling:
 # ===========================================================================
 
 
-@pytest.mark.asyncio
 class TestHandleRawResponse:
     async def test_handle_raw_response_catches_handler_exception(
         self, dispatcher, bot
@@ -854,7 +849,6 @@ class TestHandlerBaseFilterArg:
 # ===========================================================================
 
 
-@pytest.mark.asyncio
 class TestFetchUpdatesOnce:
     """Тесты всех веток _fetch_updates_once."""
 
@@ -908,7 +902,6 @@ class TestFetchUpdatesOnce:
 # ===========================================================================
 
 
-@pytest.mark.asyncio
 class TestDispatchFetchedEvents:
     """Тесты _dispatch_fetched_events."""
 
@@ -997,13 +990,12 @@ class TestDispatchFetchedEvents:
 
 
 # ===========================================================================
-# call_handler — **data передаётся хендлеру (line 362)
+# call_handler — **data передаётся хендлеру
 # ===========================================================================
 
 
-@pytest.mark.asyncio
 class TestCallHandlerWithKwargs:
-    """Покрывает line 362: await handler.func_event(event_object, **data)"""
+    """Хендлер получает kwargs, возвращённые BaseFilter."""
 
     async def test_handler_receives_kwargs_from_base_filter(
         self, dispatcher, bot, fixture_message_created
@@ -1028,13 +1020,12 @@ class TestCallHandlerWithKwargs:
 
 
 # ===========================================================================
-# _iter_routers — вложенные роутеры (lines 463-473) и цикл (line 439)
+# _iter_routers — вложенные роутеры и защита от циклов
 # ===========================================================================
 
 
-@pytest.mark.asyncio
 class TestIterRoutersNested:
-    """Покрывает lines 463-473: рекурсивный обход sub-роутеров."""
+    """Рекурсивный обход sub-роутеров доходит до вложенных обработчиков."""
 
     async def test_nested_sub_router_handler_is_dispatched(
         self, dispatcher, bot, fixture_message_created
@@ -1059,10 +1050,7 @@ class TestIterRoutersNested:
 
 
 class TestIterRoutersCycle:
-    """
-    Покрывает line 439: цикл в графе роутеров
-    обрабатывается без зависания.
-    """
+    """Цикл в графе роутеров обрабатывается без зависания."""
 
     def test_cycle_detection_does_not_hang(self, dispatcher):
         r_a = Router(router_id="cycle_a")
@@ -1079,12 +1067,12 @@ class TestIterRoutersCycle:
 
 
 # ===========================================================================
-# _iter_unique_routers — предупреждение о дублях (lines 521-530, 535)
+# _iter_unique_routers — предупреждение о дублях
 # ===========================================================================
 
 
 class TestDuplicateRouterWarning:
-    """Покрывает lines 521-530, 535."""
+    """Повторное включение одного и того же роутера логирует предупреждение."""
 
     def test_warns_on_duplicate_inclusion(self, dispatcher, caplog):
         router = Router(router_id="dup_router")
@@ -1102,16 +1090,15 @@ class TestDuplicateRouterWarning:
 
 
 # ===========================================================================
-# Фильтры на уровне роутера (lines 560, 563, 851)
+# Фильтры на уровне роутера
 # ===========================================================================
 
 
-@pytest.mark.asyncio
 class TestRouterLevelFilters:
     async def test_failing_magic_filter_skips_router(
         self, dispatcher, bot, fixture_message_created
     ):
-        """Покрывает lines 560, 851: failing MagicFilter → continue."""
+        """Неподходящий MagicFilter на роутере пропускает весь роутер."""
         handled = []
 
         router = Router(router_id="filtered_router")
@@ -1131,10 +1118,7 @@ class TestRouterLevelFilters:
     async def test_router_base_filter_calls_process_base_filters(
         self, dispatcher, bot, fixture_message_created
     ):
-        """
-        Покрывает line 563: process_base_filters
-        вызывается для router.base_filters.
-        """
+        """BaseFilter на роутере вызывается и передаёт данные в обработчик."""
         from maxapi.filters.filter import BaseFilter
 
         enriched: dict = {}
@@ -1159,13 +1143,12 @@ class TestRouterLevelFilters:
 
 
 # ===========================================================================
-# Middleware на уровне роутера (lines 806-809)
+# Middleware на уровне роутера
 # ===========================================================================
 
 
-@pytest.mark.asyncio
 class TestRouterMiddlewareChain:
-    """Покрывает lines 806-809."""
+    """Middleware, добавленный на роутер, оборачивает его обработчики."""
 
     async def test_router_middleware_wraps_dispatch(
         self, dispatcher, bot, fixture_message_created
@@ -1196,13 +1179,12 @@ class TestRouterMiddlewareChain:
 
 
 # ===========================================================================
-# ClientConnectorError в _dispatch_fetched_events (lines 1052-1058)
+# ClientConnectorError в _dispatch_fetched_events
 # ===========================================================================
 
 
-@pytest.mark.asyncio
 class TestDispatchFetchedEventsConnectorError:
-    """Покрывает lines 1052-1058."""
+    """_dispatch_fetched_events перехватывает сетевые и прочие исключения."""
 
     async def test_client_connector_error_caught_and_logged(
         self, dispatcher, bot
@@ -1230,10 +1212,7 @@ class TestDispatchFetchedEventsConnectorError:
             )  # не должно всплывать
 
     async def test_generic_exception_caught_and_logged(self, dispatcher, bot):
-        """
-        Покрывает lines 1057-1058: generic Exception
-        в _dispatch_fetched_events.
-        """
+        """Произвольное исключение в _dispatch_fetched_events не всплывает."""
         dispatcher.bot = bot
         _setup_for_handle(dispatcher, bot)
 
@@ -1251,14 +1230,13 @@ class TestDispatchFetchedEventsConnectorError:
 
 
 # ===========================================================================
-# start_polling — полный HTTP-цикл через aresponses (lines 1072-1082)
+# start_polling — полный HTTP-цикл через aresponses
 # ===========================================================================
 
 
-@pytest.mark.asyncio
 class TestStartPollingWithAresponses:
     """
-    Покрывает lines 1072-1082 через реальную сетевую эмуляцию (aresponses).
+    Интеграционный тест start_polling через сетевую эмуляцию (aresponses).
 
     aresponses перехватывает TCP-соединения на уровне резолвера и
     перенаправляет их на локальный mock-сервер — никакого реального
@@ -1270,9 +1248,9 @@ class TestStartPollingWithAresponses:
     ):
         """
         Проверяет, что start_polling:
-          1. обращается к /me (check_me)            ← lines 1072-1074
-          2. первый /updates возвращает 500 → returns None      ← line 1081
-          3. второй /updates возвращает {} → _dispatch вызван   ← line 1082
+          1. обращается к /me (check_me)
+          2. первый /updates возвращает 500 → _fetch_updates_once → None
+          3. второй /updates возвращает {} → _dispatch_fetched_events вызван
         """
         from aiohttp import web
         from maxapi.bot import Bot
@@ -1337,13 +1315,12 @@ class TestStartPollingWithAresponses:
 
 
 # ===========================================================================
-# startup (line 1119)
+# startup
 # ===========================================================================
 
 
-@pytest.mark.asyncio
 class TestStartup:
-    """Покрывает line 1119."""
+    """startup() привязывает бота и подготавливает обработчики."""
 
     async def test_startup_calls_ready(self, dispatcher, bot):
         dispatcher.check_me = AsyncMock()
@@ -1358,13 +1335,12 @@ class TestStartup:
 
 
 # ===========================================================================
-# handle_webhook (lines 1154-1155)
+# handle_webhook
 # ===========================================================================
 
 
-@pytest.mark.asyncio
 class TestHandleWebhook:
-    """Покрывает lines 1154-1155."""
+    """handle_webhook() создаёт экземпляр webhook-класса и запускает его."""
 
     async def test_handle_webhook_creates_and_runs_instance(
         self, dispatcher, bot
@@ -1390,12 +1366,12 @@ class TestHandleWebhook:
 
 
 # ===========================================================================
-# Устаревшее событие — DeprecationWarning (line 1240)
+# Устаревшее событие — DeprecationWarning
 # ===========================================================================
 
 
 class TestDeprecatedEvent:
-    """Покрывает line 1240."""
+    """Регистрация на устаревшее событие вызывает DeprecationWarning."""
 
     def test_deprecated_event_emits_deprecation_warning(self):
         import warnings
@@ -1409,3 +1385,27 @@ class TestDeprecatedEvent:
                 pass
 
         assert any(issubclass(x.category, DeprecationWarning) for x in w)
+
+
+# ===========================================================================
+# _on_background_task_done — ветка с исключением в задаче
+# ===========================================================================
+
+
+class TestOnBackgroundTaskDone:
+    """_on_background_task_done логирует исключение упавшей задачи."""
+
+    async def test_logs_exception_when_task_has_exception(self, dispatcher):
+        """Callback логирует исключение, если задача завершилась с ошибкой."""
+
+        async def _failing():
+            raise RuntimeError("test error from background task")
+
+        task = asyncio.create_task(_failing())
+        dispatcher._background_tasks.add(task)
+        # Ждём завершения, подавляя исключение
+        await asyncio.gather(task, return_exceptions=True)
+
+        with patch("maxapi.dispatcher.logger_dp") as mock_logger:
+            dispatcher._on_background_task_done(task)
+            mock_logger.exception.assert_called_once()

--- a/tests/test_enrich_event.py
+++ b/tests/test_enrich_event.py
@@ -1,14 +1,22 @@
-"""Тесты для maxapi/utils/updates.py — функция enrich_event.
+"""Тесты для maxapi/utils/updates.py.
 
-Покрываются все ветки логики: auto_requests=False, каждый тип события,
-is_chat_unavailable для DialogRemoved и BotRemoved-из-канала.
+Покрывает:
+  - _resolve_chat   : все ветки разрешения chat_id
+  - _resolve_from_user : все ветки определения отправителя
+  - _inject_bot     : внедрение ссылки на бота
+  - enrich_event    : сквозной пайплайн + auto_requests=False
 """
 
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from maxapi.enums.chat_type import ChatType
-from maxapi.utils.updates import enrich_event
+from maxapi.utils.updates import (
+    _inject_bot,
+    _resolve_chat,
+    _resolve_from_user,
+    enrich_event,
+)
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -21,272 +29,387 @@ def _make_chat(chat_type: ChatType = ChatType.CHAT):
     return chat
 
 
-# ---------------------------------------------------------------------------
-# auto_requests=False — ранний выход без каких-либо API-вызовов
-# ---------------------------------------------------------------------------
+# ===========================================================================
+# _resolve_chat
+# ===========================================================================
 
 
-async def test_enrich_event_auto_requests_false_returns_unchanged(
-    bot, fixture_message_created
-):
-    bot.auto_requests = False
-    result = await enrich_event(fixture_message_created, bot)
-    assert result is fixture_message_created
+class TestResolveChat:
+    """Юнит-тесты для _resolve_chat."""
+
+    async def test_bot_removed_never_fetches_chat(
+        self, bot, fixture_bot_removed
+    ):
+        """
+        BotRemoved всегда пропускает загрузку чата,
+        независимо от is_channel.
+        """
+        bot.get_chat_by_id = AsyncMock()
+
+        for is_channel in (True, False):
+            fixture_bot_removed.is_channel = is_channel
+            fixture_bot_removed.chat = None
+            await _resolve_chat(fixture_bot_removed, bot)
+
+        bot.get_chat_by_id.assert_not_called()
+        assert fixture_bot_removed.chat is None
+
+    async def test_dialog_removed_never_fetches_chat(
+        self, bot, fixture_dialog_removed
+    ):
+        """DialogRemoved всегда пропускает загрузку чата."""
+        bot.get_chat_by_id = AsyncMock()
+
+        await _resolve_chat(fixture_dialog_removed, bot)
+
+        bot.get_chat_by_id.assert_not_called()
+        assert fixture_dialog_removed.chat is None
+
+    async def test_event_with_top_level_chat_id_fetches_chat(
+        self, bot, fixture_bot_started
+    ):
+        """События с chat_id на верхнем уровне загружают чат по нему."""
+        fake_chat = _make_chat()
+        bot.get_chat_by_id = AsyncMock(return_value=fake_chat)
+
+        await _resolve_chat(fixture_bot_started, bot)
+
+        bot.get_chat_by_id.assert_awaited_once_with(
+            fixture_bot_started.chat_id
+        )
+        assert fixture_bot_started.chat is fake_chat
+
+    async def test_message_created_falls_back_to_recipient_chat_id(
+        self, bot, fixture_message_created
+    ):
+        """MessageCreated не имеет top-level chat_id — берётся из recipient."""
+        fake_chat = _make_chat()
+        bot.get_chat_by_id = AsyncMock(return_value=fake_chat)
+
+        await _resolve_chat(fixture_message_created, bot)
+
+        expected_chat_id = fixture_message_created.message.recipient.chat_id
+        bot.get_chat_by_id.assert_awaited_once_with(expected_chat_id)
+        assert fixture_message_created.chat is fake_chat
+
+    async def test_message_created_no_chat_id_anywhere_skips_fetch(
+        self, bot, fixture_message_created
+    ):
+        """Если recipient.chat_id = None — get_chat_by_id не вызывается."""
+        fixture_message_created.message.recipient.chat_id = None
+        bot.get_chat_by_id = AsyncMock()
+
+        await _resolve_chat(fixture_message_created, bot)
+
+        bot.get_chat_by_id.assert_not_called()
+        assert fixture_message_created.chat is None
+
+    async def test_message_edited_falls_back_to_recipient_chat_id(
+        self, bot, fixture_message_edited
+    ):
+        """MessageEdited аналогично MessageCreated."""
+        fake_chat = _make_chat()
+        bot.get_chat_by_id = AsyncMock(return_value=fake_chat)
+
+        await _resolve_chat(fixture_message_edited, bot)
+
+        expected_chat_id = fixture_message_edited.message.recipient.chat_id
+        bot.get_chat_by_id.assert_awaited_once_with(expected_chat_id)
+
+    async def test_message_callback_falls_back_to_recipient_chat_id(
+        self, bot, fixture_message_callback
+    ):
+        """MessageCallback берёт chat_id из message.recipient."""
+        fake_chat = _make_chat()
+        bot.get_chat_by_id = AsyncMock(return_value=fake_chat)
+
+        await _resolve_chat(fixture_message_callback, bot)
+
+        expected_chat_id = fixture_message_callback.message.recipient.chat_id
+        bot.get_chat_by_id.assert_awaited_once_with(expected_chat_id)
+
+    async def test_message_callback_none_message_skips_fetch(
+        self, bot, fixture_message_callback
+    ):
+        """Если message=None — get_chat_by_id не вызывается."""
+        fixture_message_callback.message = None
+        bot.get_chat_by_id = AsyncMock()
+
+        await _resolve_chat(fixture_message_callback, bot)
+
+        bot.get_chat_by_id.assert_not_called()
 
 
-# ---------------------------------------------------------------------------
-# DialogRemoved — chat=None, from_user=user, get_chat_by_id НЕ вызывается
-# ---------------------------------------------------------------------------
+# ===========================================================================
+# _resolve_from_user
+# ===========================================================================
 
 
-async def test_enrich_event_dialog_removed_sets_from_user(
-    bot, fixture_dialog_removed
-):
-    bot.get_chat_by_id = AsyncMock()
+class TestResolveFromUser:
+    """Юнит-тесты для _resolve_from_user."""
 
-    result = await enrich_event(fixture_dialog_removed, bot)
+    async def test_message_created_sets_sender(
+        self, bot, fixture_message_created
+    ):
+        await _resolve_from_user(fixture_message_created, bot)
+        assert (
+            fixture_message_created.from_user
+            is fixture_message_created.message.sender
+        )
 
-    bot.get_chat_by_id.assert_not_called()
-    assert result.chat is None
-    assert result.from_user is fixture_dialog_removed.user
+    async def test_message_edited_sets_sender(
+        self, bot, fixture_message_edited
+    ):
+        await _resolve_from_user(fixture_message_edited, bot)
+        assert (
+            fixture_message_edited.from_user
+            is fixture_message_edited.message.sender
+        )
 
+    async def test_message_callback_sets_callback_user(
+        self, bot, fixture_message_callback
+    ):
+        await _resolve_from_user(fixture_message_callback, bot)
+        assert (
+            fixture_message_callback.from_user
+            is fixture_message_callback.callback.user
+        )
 
-# ---------------------------------------------------------------------------
-# BotRemoved из канала — chat=None, get_chat_by_id НЕ вызывается
-# ---------------------------------------------------------------------------
+    async def test_message_removed_chat_type_fetches_member(
+        self, bot, fixture_message_removed
+    ):
+        """CHAT-тип — from_user берётся через get_chat_member(user_id)."""
+        fake_chat = _make_chat(ChatType.CHAT)
+        fake_member = MagicMock()
+        fixture_message_removed.chat = fake_chat
+        bot.get_chat_member = AsyncMock(return_value=fake_member)
 
+        await _resolve_from_user(fixture_message_removed, bot)
 
-async def test_enrich_event_bot_removed_from_channel_chat_is_none(
-    bot, fixture_bot_removed
-):
-    fixture_bot_removed.is_channel = True
-    bot.get_chat_by_id = AsyncMock()
+        bot.get_chat_member.assert_awaited_once_with(
+            chat_id=fixture_message_removed.chat_id,
+            user_id=fixture_message_removed.user_id,
+        )
+        assert fixture_message_removed.from_user is fake_member
 
-    result = await enrich_event(fixture_bot_removed, bot)
+    async def test_message_removed_dialog_type_sets_chat(
+        self, bot, fixture_message_removed
+    ):
+        """DIALOG-тип — from_user = chat."""
+        fake_chat = _make_chat(ChatType.DIALOG)
+        fixture_message_removed.chat = fake_chat
+        bot.get_chat_member = AsyncMock()
 
-    bot.get_chat_by_id.assert_not_called()
-    assert result.chat is None
+        await _resolve_from_user(fixture_message_removed, bot)
 
+        bot.get_chat_member.assert_not_called()
+        assert fixture_message_removed.from_user is fake_chat
 
-# ---------------------------------------------------------------------------
-# BotRemoved НЕ из канала — get_chat_by_id вызывается
-# ---------------------------------------------------------------------------
+    async def test_message_removed_no_chat_skips_from_user(
+        self, bot, fixture_message_removed
+    ):
+        """Если chat=None — from_user не устанавливается."""
+        fixture_message_removed.chat = None
+        bot.get_chat_member = AsyncMock()
 
+        await _resolve_from_user(fixture_message_removed, bot)
 
-async def test_enrich_event_bot_removed_not_channel_fetches_chat(
-    bot, fixture_bot_removed
-):
-    fixture_bot_removed.is_channel = False
-    fake_chat = _make_chat()
-    bot.get_chat_by_id = AsyncMock(return_value=fake_chat)
+        bot.get_chat_member.assert_not_called()
+        assert fixture_message_removed.from_user is None
 
-    result = await enrich_event(fixture_bot_removed, bot)
+    async def test_user_removed_with_admin_id_fetches_member(
+        self, bot, fixture_user_removed
+    ):
+        fake_member = MagicMock()
+        fixture_user_removed.admin_id = 9999
+        bot.get_chat_member = AsyncMock(return_value=fake_member)
 
-    bot.get_chat_by_id.assert_awaited_once_with(fixture_bot_removed.chat_id)
-    assert result.chat is fake_chat
-    assert result.from_user is fixture_bot_removed.user
+        await _resolve_from_user(fixture_user_removed, bot)
 
+        bot.get_chat_member.assert_awaited_once_with(
+            chat_id=fixture_user_removed.chat_id,
+            user_id=fixture_user_removed.admin_id,
+        )
+        assert fixture_user_removed.from_user is fake_member
 
-# ---------------------------------------------------------------------------
-# MessageCreated — from_user=sender, get_chat_by_id вызывается
-# ---------------------------------------------------------------------------
+    async def test_user_removed_without_admin_id_skips_member(
+        self, bot, fixture_user_removed
+    ):
+        fixture_user_removed.admin_id = None
+        bot.get_chat_member = AsyncMock()
 
+        await _resolve_from_user(fixture_user_removed, bot)
 
-async def test_enrich_event_message_created_sets_from_user_and_chat(
-    bot, fixture_message_created
-):
-    fake_chat = _make_chat(ChatType.DIALOG)
-    bot.get_chat_by_id = AsyncMock(return_value=fake_chat)
+        bot.get_chat_member.assert_not_called()
+        assert fixture_user_removed.from_user is None
 
-    result = await enrich_event(fixture_message_created, bot)
-
-    assert result.from_user is fixture_message_created.message.sender
-    assert result.bot is bot
-
-
-async def test_enrich_event_message_created_skips_get_chat_if_already_set(
-    bot, fixture_message_created
-):
-    """Если chat уже выставлен на верхнем уровне, повторный запрос
-    для recipient не делается."""
-    existing_chat = _make_chat()
-    fixture_message_created.chat = existing_chat
-    # recipient.chat_id есть, но chat уже не None — второй вызов не нужен
-    bot.get_chat_by_id = AsyncMock(return_value=existing_chat)
-
-    await enrich_event(fixture_message_created, bot)
-
-    # get_chat_by_id вызывается только один раз (верхний блок chat_id)
-    assert bot.get_chat_by_id.await_count <= 1
-
-
-# ---------------------------------------------------------------------------
-# MessageEdited
-# ---------------------------------------------------------------------------
-
-
-async def test_enrich_event_message_edited_sets_from_user(
-    bot, fixture_message_edited
-):
-    fake_chat = _make_chat()
-    bot.get_chat_by_id = AsyncMock(return_value=fake_chat)
-
-    result = await enrich_event(fixture_message_edited, bot)
-
-    assert result.from_user is fixture_message_edited.message.sender
-    assert result.bot is bot
-
-
-# ---------------------------------------------------------------------------
-# MessageCallback
-# ---------------------------------------------------------------------------
-
-
-async def test_enrich_event_message_callback_sets_from_user(
-    bot, fixture_message_callback
-):
-    fake_chat = _make_chat()
-    bot.get_chat_by_id = AsyncMock(return_value=fake_chat)
-
-    result = await enrich_event(fixture_message_callback, bot)
-
-    assert result.from_user is fixture_message_callback.callback.user
-    assert result.bot is bot
-
-
-async def test_enrich_event_message_callback_none_message(
-    bot, fixture_message_callback
-):
-    """Если message=None — from_user всё равно берётся из callback.user."""
-    fixture_message_callback.message = None
-    bot.get_chat_by_id = AsyncMock()
-
-    result = await enrich_event(fixture_message_callback, bot)
-
-    assert result.from_user is fixture_message_callback.callback.user
-
-
-# ---------------------------------------------------------------------------
-# MessageRemoved — CHAT type → from_user из get_chat_member
-# ---------------------------------------------------------------------------
-
-
-async def test_enrich_event_message_removed_chat_type(
-    bot, fixture_message_removed
-):
-    fake_chat = _make_chat(ChatType.CHAT)
-    fake_member = MagicMock()
-    bot.get_chat_by_id = AsyncMock(return_value=fake_chat)
-    bot.get_chat_member = AsyncMock(return_value=fake_member)
-
-    result = await enrich_event(fixture_message_removed, bot)
-
-    bot.get_chat_member.assert_awaited_once_with(
-        chat_id=fixture_message_removed.chat_id,
-        user_id=fixture_message_removed.user_id,
+    @pytest.mark.parametrize(
+        "fixture_name",
+        [
+            "fixture_user_added",
+            "fixture_bot_added",
+            "fixture_bot_removed",
+            "fixture_bot_started",
+            "fixture_bot_stopped",
+            "fixture_chat_title_changed",
+            "fixture_dialog_cleared",
+            "fixture_dialog_muted",
+            "fixture_dialog_unmuted",
+            "fixture_dialog_removed",
+        ],
     )
-    assert result.from_user is fake_member
+    async def test_events_with_user_attr_set_from_user(
+        self, request, bot, fixture_name
+    ):
+        """Все типы из _EVENTS_WITH_USER_ATTR получают from_user = user."""
+        event = request.getfixturevalue(fixture_name)
+        await _resolve_from_user(event, bot)
+        assert event.from_user is event.user
 
 
-# ---------------------------------------------------------------------------
-# MessageRemoved — DIALOG type → from_user = chat
-# ---------------------------------------------------------------------------
+# ===========================================================================
+# _inject_bot
+# ===========================================================================
 
 
-async def test_enrich_event_message_removed_dialog_type(
-    bot, fixture_message_removed
-):
-    fake_chat = _make_chat(ChatType.DIALOG)
-    bot.get_chat_by_id = AsyncMock(return_value=fake_chat)
-    bot.get_chat_member = AsyncMock()
+class TestInjectBot:
+    """Юнит-тесты для _inject_bot."""
 
-    result = await enrich_event(fixture_message_removed, bot)
+    def test_sets_bot_on_message(self, bot, fixture_message_created):
+        _inject_bot(fixture_message_created, bot)
+        assert fixture_message_created.message.bot is bot
 
-    bot.get_chat_member.assert_not_called()
-    assert result.from_user is fake_chat
+    def test_sets_bot_on_event(self, bot, fixture_bot_started):
+        _inject_bot(fixture_bot_started, bot)
+        assert fixture_bot_started.bot is bot
+
+    def test_sets_bot_on_attachment_with_bot_attr(
+        self, bot, fixture_message_created
+    ):
+        att_with_bot = MagicMock(spec=["bot"])
+        att_without_bot = MagicMock(spec=[])
+        fixture_message_created.message.body.attachments = [
+            att_with_bot,
+            att_without_bot,
+        ]
+
+        _inject_bot(fixture_message_created, bot)
+
+        assert att_with_bot.bot is bot
+        # att_without_bot не получает ошибки
+
+    def test_message_body_none_no_error(self, bot, fixture_message_created):
+        """Если body=None — нет ошибки."""
+        fixture_message_created.message.body = None
+        _inject_bot(fixture_message_created, bot)  # не должно падать
+
+    def test_message_none_no_error(self, bot, fixture_message_callback):
+        """Если message=None — нет ошибки."""
+        fixture_message_callback.message = None
+        _inject_bot(fixture_message_callback, bot)  # не должно падать
 
 
-# ---------------------------------------------------------------------------
-# UserRemoved — с admin_id → from_user из get_chat_member
-# ---------------------------------------------------------------------------
+# ===========================================================================
+# enrich_event — сквозной пайплайн
+# ===========================================================================
 
 
-async def test_enrich_event_user_removed_with_admin(bot, fixture_user_removed):
-    fixture_user_removed.admin_id = 9999
-    fake_chat = _make_chat()
-    fake_member = MagicMock()
-    bot.get_chat_by_id = AsyncMock(return_value=fake_chat)
-    bot.get_chat_member = AsyncMock(return_value=fake_member)
+class TestEnrichEvent:
+    """Интеграционные тесты для enrich_event."""
 
-    result = await enrich_event(fixture_user_removed, bot)
+    async def test_auto_requests_false_returns_unchanged(
+        self, bot, fixture_message_created
+    ):
+        """auto_requests=False — ранний выход, объект не изменяется."""
+        bot.auto_requests = False
+        result = await enrich_event(fixture_message_created, bot)
+        assert result is fixture_message_created
 
-    bot.get_chat_member.assert_awaited_once_with(
-        chat_id=fixture_user_removed.chat_id,
-        user_id=fixture_user_removed.admin_id,
+    async def test_full_pipeline_message_created(
+        self, bot, fixture_message_created
+    ):
+        """Пайплайн: chat, from_user и bot выставляются для MessageCreated."""
+        fake_chat = _make_chat(ChatType.DIALOG)
+        bot.get_chat_by_id = AsyncMock(return_value=fake_chat)
+
+        result = await enrich_event(fixture_message_created, bot)
+
+        assert result.chat is fake_chat
+        assert result.from_user is fixture_message_created.message.sender
+        assert result.bot is bot
+        assert result.message.bot is bot
+
+    async def test_full_pipeline_bot_removed(self, bot, fixture_bot_removed):
+        """BotRemoved: chat=None, from_user=user, bot проставлен."""
+        bot.get_chat_by_id = AsyncMock()
+
+        result = await enrich_event(fixture_bot_removed, bot)
+
+        bot.get_chat_by_id.assert_not_called()
+        assert result.chat is None
+        assert result.from_user is fixture_bot_removed.user
+        assert result.bot is bot
+
+    async def test_full_pipeline_dialog_removed(
+        self, bot, fixture_dialog_removed
+    ):
+        """DialogRemoved: chat=None, from_user=user."""
+        bot.get_chat_by_id = AsyncMock()
+
+        result = await enrich_event(fixture_dialog_removed, bot)
+
+        bot.get_chat_by_id.assert_not_called()
+        assert result.chat is None
+        assert result.from_user is fixture_dialog_removed.user
+
+    async def test_full_pipeline_message_removed_chat_type(
+        self, bot, fixture_message_removed
+    ):
+        fake_chat = _make_chat(ChatType.CHAT)
+        fake_member = MagicMock()
+        bot.get_chat_by_id = AsyncMock(return_value=fake_chat)
+        bot.get_chat_member = AsyncMock(return_value=fake_member)
+
+        result = await enrich_event(fixture_message_removed, bot)
+
+        assert result.from_user is fake_member
+
+    async def test_full_pipeline_message_removed_dialog_type(
+        self, bot, fixture_message_removed
+    ):
+        fake_chat = _make_chat(ChatType.DIALOG)
+        bot.get_chat_by_id = AsyncMock(return_value=fake_chat)
+        bot.get_chat_member = AsyncMock()
+
+        result = await enrich_event(fixture_message_removed, bot)
+
+        bot.get_chat_member.assert_not_called()
+        assert result.from_user is fake_chat
+
+    @pytest.mark.parametrize(
+        "fixture_name",
+        [
+            "fixture_user_added",
+            "fixture_bot_added",
+            "fixture_bot_started",
+            "fixture_bot_stopped",
+            "fixture_chat_title_changed",
+            "fixture_dialog_cleared",
+            "fixture_dialog_muted",
+            "fixture_dialog_unmuted",
+        ],
     )
-    assert result.from_user is fake_member
+    async def test_full_pipeline_common_events(
+        self, request, bot, fixture_name
+    ):
+        """Все 'обычные' события: chat загружается, from_user = user."""
+        event = request.getfixturevalue(fixture_name)
+        fake_chat = _make_chat()
+        bot.get_chat_by_id = AsyncMock(return_value=fake_chat)
 
+        result = await enrich_event(event, bot)
 
-# ---------------------------------------------------------------------------
-# UserRemoved — без admin_id → get_chat_member не вызывается
-# ---------------------------------------------------------------------------
-
-
-async def test_enrich_event_user_removed_no_admin(bot, fixture_user_removed):
-    fixture_user_removed.admin_id = None
-    fake_chat = _make_chat()
-    bot.get_chat_by_id = AsyncMock(return_value=fake_chat)
-    bot.get_chat_member = AsyncMock()
-
-    result = await enrich_event(fixture_user_removed, bot)
-
-    bot.get_chat_member.assert_not_called()
-    assert result.chat is fake_chat
-
-
-# ---------------------------------------------------------------------------
-# Группа: UserAdded, BotAdded, BotStarted, BotStopped,
-#          ChatTitleChanged, DialogCleared, DialogMuted, DialogUnmuted
-#          — from_user=user, get_chat_by_id вызывается
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.parametrize(
-    "fixture_name",
-    [
-        "fixture_user_added",
-        "fixture_bot_added",
-        "fixture_bot_started",
-        "fixture_bot_stopped",
-        "fixture_chat_title_changed",
-        "fixture_dialog_cleared",
-        "fixture_dialog_muted",
-        "fixture_dialog_unmuted",
-    ],
-)
-async def test_enrich_event_common_events_set_from_user(
-    request, bot, fixture_name
-):
-    event = request.getfixturevalue(fixture_name)
-    fake_chat = _make_chat()
-    bot.get_chat_by_id = AsyncMock(return_value=fake_chat)
-
-    result = await enrich_event(event, bot)
-
-    bot.get_chat_by_id.assert_awaited_once_with(event.chat_id)
-    assert result.chat is fake_chat
-    assert result.from_user is event.user
-
-
-# ---------------------------------------------------------------------------
-# bot ссылка проставляется на event_object
-# ---------------------------------------------------------------------------
-
-
-async def test_enrich_event_sets_bot_on_event(bot, fixture_bot_started):
-    fake_chat = _make_chat()
-    bot.get_chat_by_id = AsyncMock(return_value=fake_chat)
-
-    result = await enrich_event(fixture_bot_started, bot)
-
-    assert result.bot is bot
+        bot.get_chat_by_id.assert_awaited_once_with(event.chat_id)
+        assert result.chat is fake_chat
+        assert result.from_user is event.user
+        assert result.bot is bot

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -163,6 +163,5 @@ class TestDispatcherIntegration:
 
         await dp.check_me()
 
-        # check_me() устанавливает _me
-        assert integration_bot.me is not None
+        # check_me() устанавливает bot.me
         assert integration_bot.me is not None

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -164,5 +164,5 @@ class TestDispatcherIntegration:
         await dp.check_me()
 
         # check_me() устанавливает _me
-        assert integration_bot._me is not None
+        assert integration_bot.me is not None
         assert integration_bot.me is not None


### PR DESCRIPTION
Ниже идёт очень жирный отчёт, но я настоятельно рекомендую его прочитать. И в образовательных целях, и в целях упрощения проведения review

.
.
.
.

## 🔍 Точки оптимизации

### 1. ✅ `handle()` — двухуровневое вложение замыканий + `nonlocal`

**Было:**

```python
async def handle(self, event_object):
    is_handled = False

    async def _process_event(_, data):
        nonlocal router_id, is_handled          # ← мутабельный захват

        for index, (router, ...) in enumerate(self._iter_unique_routers(...)):
            ...
            async def _process_handlers(event, handler_data):
                nonlocal is_handled             # ← второй уровень nonlocal
                for handler in matching_handlers:
                    ...
                    is_handled = True
                    break

            if router_middlewares:
                router_chain = self.build_middleware_chain(
                    router_middlewares, _process_handlers   # ← замыкание
                )
                await router_chain(event_object, data)
            else:
                await _process_handlers(event_object, data)

    global_chain = self.build_middleware_chain(self.middlewares, _process_event)
    await global_chain(event_object, kwargs)
```

**Проблемы:**
- **Двухуровневое вложение**: `_process_handlers` ⊂ `_process_event` ⊂ `handle` — три аллокации объектов замыканий на каждое событие.
- **`nonlocal` на двух уровнях** скрывает мутацию `is_handled`: читатель вынужден трассировать изменение переменной через вложенные функции.
- Результаты передаются через побочный эффект, а не через `return` — нарушение принципа наименьшего удивления.
- `_process_handlers` захватывает `matching_handlers`, `current_state`, `memory_context`, `router_id`, `process_info` из внешней области — любая опечатка может привести к захвату не той переменной.

**Чем чревато отсутствие:** При высоком RPS аллокации замыканий создают нагрузку на GC. При поддержке кода — риск ошибок из-за скрытых `nonlocal`-мутаций: добавление `break` или раннего `return` в цикле может сломать логику, которая работает через побочный эффект.

**Решение:** `_process_event` и `_process_handlers` выделены в полноценные методы (`_process_event`, `_invoke_router_handlers`, `_run_router_handlers`). Данные передаются через `data`-словарь с ключами `_memory_context`, `_current_state`, `_process_info`, `_router_id`, `_is_handled`.

---

### 2. ✅ `_dispatch_to_router()` — мутируемый `list[bool]` вместо возвращаемого значения

**Было:** `_process_handlers` (замыкание из п. 1) сигнализировала об успехе через мутацию `nonlocal is_handled`. Никакого явного `return` — результат читался из захваченной переменной внешней функции.

**Проблемы:**
- Нет явного `return` — из сигнатуры нельзя понять, что функция возвращает результат обработки.
- Замыкание создаётся заново на каждый роутер × каждое событие.

**Чем чревато отсутствие:** Любой рефакторинг (например, добавление `await asyncio.sleep(0)` внутри цикла) может нарушить последовательность мутации `nonlocal`-переменной — одно событие будет обработано несколькими обработчиками, несмотря на задуманную логику «первый match останавливает цикл».

**Решение:** выделен метод `_invoke_router_handlers(self, event, data, *, ...)`. Результат записывается в `data["_handled"] = True` и извлекается через `data.pop("_handled", False)`. Параметры передаются через `functools.partial` с keyword-only args.

---

### 3. ✅ `build_middleware_chain` — пересборка цепочки на каждое событие

**Было:**

```python
# В handle — на каждое событие:
global_chain = self.build_middleware_chain(self.middlewares, _process_event)

# В _dispatch_to_router — на каждый роутер × каждое событие:
chain = self.build_middleware_chain(router_middlewares, _process_handlers)

# В _execute_handler — на каждый вызов хендлера:
handler_chain = self.build_middleware_chain(
    handler.middlewares, functools.partial(self.call_handler, handler)
)
```

**Проблема:** три пересборки через `functools.partial` на каждое событие. Middleware-списки стабильны после `__ready()` — пересборка бессмысленна.

**Чем чревато отсутствие:** При M middleware × N роутерах каждое событие создаёт `M × N` объектов `functools.partial`. При 10 роутерах × 3 middleware = 30 аллокаций на событие только на middleware-цепочки. Под нагрузкой это заметно в профилировщике как «hot path alloc».

**Решение:**
- Глобальная цепочка кешируется в `self._global_mw_chain` при `__ready()`.
- Handler-цепочки кешируются в `handler.mw_chain` при `_prepare_handlers()`.
- `_execute_handler` использует `handler.mw_chain` с fallback на пересборку.
- `build_middleware_chain` стал `@staticmethod` — не читает состояние экземпляра.
- Router middleware цепочки строятся per-event (inner handler зависит от параметров события).

---

### 4. ✅ `_execute_handler` + `call_handler` — двойное вычисление `kwargs_filtered`

**Было:**

```python
# В _execute_handler:
func_args = handler.func_event.__annotations__.keys()
kwargs_filtered = {k: v for k, v in data.items() if k in func_args}
# ... chain вызывает call_handler с теми же данными ...

# В call_handler — ТО ЖЕ САМОЕ повторно:
func_args = handler.func_event.__annotations__.keys()
kwargs_filtered = {k: v for k, v in data.items() if k in func_args}
await handler.func_event(event_object, **kwargs_filtered)
```

Плюс принудительная инъекция `context` даже если обработчик его не объявляет:

```python
if "context" not in kwargs_filtered and "context" in data:
    kwargs_filtered["context"] = data["context"]
```

**Чем чревато отсутствие:** Если обработчик не принимает `context`, он всё равно получал его в kwargs — молчаливое загрязнение интерфейса. При добавлении новых внутренних ключей в `data` (например, `_memory_context`) риск «протечки» служебных ключей в аргументы пользовательского хендлера возрастает.

**Решение:** `call_handler` упрощён — принимает уже отфильтрованные kwargs и передаёт их напрямую. Принудительная инъекция `context` удалена — он попадает в хендлер только если явно объявлен в аннотациях.

---

### 5. ✅ `_check_handler_match` — дублирование логики фильтрации

**Было:**

```python
# _check_router_filters:
if filters and not filter_attrs(event, *filters):
    return False
if base_filters:
    result = await self.process_base_filters(...)
    if isinstance(result, dict): return result
    if not result: return False
return {}

# _check_handler_match — та же логика ещё раз:
if handler.filters and not filter_attrs(event, *handler.filters):
    return False
if handler.states and current_state not in handler.states:
    return False
if handler.base_filters:
    result = await self.process_base_filters(...)
    if isinstance(result, dict): return result
    if not result: return False
return {}
```

**Чем чревато отсутствие:** При необходимости добавить новый тип фильтра или изменить порядок проверок — изменение нужно вносить в два места. История показывает: такие «двойники» расходятся — в одном месте баг исправляется, в другом нет.

**Решение:** `_check_handler_match` сначала проверяет `states` (быстрый guard без `await`), затем делегирует ВСЮ фильтрацию в `_check_router_filters` — единственный источник правды для `MagicFilter + BaseFilter`.

---

### 6. ✅ `_iter_and_dispatch_routers` — `enumerate()` для `router_id`

**Было:**

```python
for index, (router, ...) in enumerate(self._iter_unique_routers(...)):
    router_id = router.router_id or index
```

**Проблема:** `index` — позиция в плоском порядке обхода при конкретном вызове. При вложенных роутерах он не отражает структуру дерева, меняется при добавлении/удалении роутеров и непригоден для сопоставления с именами в логах.

**Чем чревато отсутствие:** В логах вместо `router_id: payment_router` будет `router_id: 3` — при отладке сложных деревьев роутеров бесполезно.

**Решение:** `enumerate` убран. Fallback: `router.router_id or id(router)` — `id()` гарантированно уникален в рамках процесса и однозначно идентифицирует объект.

---

### 7. ✅ `self.contexts` — unbounded рост словаря (утечка памяти)

**Было:**

```python
self.contexts: dict[tuple[int | None, int | None], BaseContext] = {}

def __get_context(self, chat_id, user_id):
    key = (chat_id, user_id)
    if key in self.contexts:
        return self.contexts[key]
    self.contexts[key] = self.storage(chat_id, user_id, **self.storage_kwargs)
    return self.contexts[key]
```

**Чем чревато отсутствие:** В боте с тысячами пользователей словарь растёт линейно и никогда не очищается. При `MemoryContext` это пустые объекты состояния для давно ушедших пользователей — они занимают память, которая не освобождается без перезапуска. При 100 000 уникальных пользователях — реальная утечка памяти.

**Решение:** `self.contexts` заменён на `OrderedDict` с LRU-логикой (stdlib, без внешних зависимостей):
- При попадании: `move_to_end(key)` — помечает ключ как «недавно использованный».
- При создании нового: если `len >= CONTEXTS_MAX_SIZE (10_000)` — `popitem(last=False)` вытесняет самый давний.

---

### 8. ✅ `process_base_filters` — неоднозначный return type

**Было:**

```python
async def process_base_filters(...) -> dict[str, Any] | None | Literal[False]:
    ...
    elif not result:
        return result   # ← None, False, 0, "" — всё что falsy
    return data
```

**Проблема:** три варианта типа усложняли все вызывающие места:

```python
if isinstance(result, dict):
    return result
if not result:
    return False
# Что если result == {} (пустой dict — тоже falsy)?
```

Пустой `{}` — это falsy, поэтому `if not result` для «успешно прошедшего» фильтра с пустым результатом ошибочно квалифицировал бы его как «не прошёл».

**Чем чревато отсутствие:** Потенциально сложно воспроизводимые ошибки при написании пользовательских фильтров, возвращающих пустой dict — логически «прошёл», а диспетчер считает «не прошёл».

**Решение:** возвращает `dict[str, Any] | None`. `None` = не прошёл, `dict` (в том числе пустой) = прошёл. Все вызывающие места проверяют `if result is None`. Тест `test_process_base_filters_false` обновлён: `assert result is None`.

---

### 9. ✅ `_prepare_handlers` — отсутствие индексов и кешей при старте

**Было:**

```python
def _prepare_handlers(self, bot: Bot) -> None:
    handlers_count = 0
    for router, *_ in self._iter_unique_routers(self.routers, warn_duplicates=True):
        router.bot = bot
        for handler in router.event_handlers:
            handlers_count += 1
            extract_commands(handler, bot)
    logger_dp.info(...)
```

Метод только считал обработчики — никакие структуры для ускорения поиска не строились.

**Чем чревато отсутствие:** Три последствия, проявляющиеся на каждом событии:
1. Поиск обработчиков по `update_type` — O(n) перебор `event_handlers`.
2. `handler.func_event.__annotations__` читается при каждом вызове хендлера.
3. Дерево роутеров обходится рекурсивно заново.

**Решение:** `_prepare_handlers` строит четыре кеша за один проход:

```python
router.handlers_by_type = {}   # dict[UpdateType, list[Handler]] — O(1) поиск
handler.func_args = frozenset(handler.func_event.__annotations__)  # кеш аргументов
handler.mw_chain = build_middleware_chain(...)                     # кеш цепочки
self._cached_router_entries = list(self._iter_unique_routers(...)) # кеш обхода
```

---

### 10. ✅ `_find_matching_handlers` — линейный поиск O(n) → словарный индекс O(1)

**Было:**

```python
def _find_matching_handlers(self, router, event_type):
    return [
        handler
        for handler in router.event_handlers
        if handler.update_type == event_type
    ]
```

**Чем чревато отсутствие:** При роутере с 50 обработчиками и 10 роутерах — 500 сравнений строк на каждое входящее событие только для поиска подходящих хендлеров. С индексом — 10 dict-lookup'ов. Разница растёт линейно с ростом числа обработчиков.

**Решение:** `_prepare_handlers` строит `router.handlers_by_type: dict[UpdateType, list[Handler]]`. Метод использует индекс с fallback для случаев когда `_prepare_handlers` ещё не вызван:

```python
@staticmethod
def _find_matching_handlers(router, event_type):
    index = router.handlers_by_type
    if index is not None:
        return index.get(event_type, [])
    return [h for h in router.event_handlers if h.update_type == event_type]
```

---

### 11. ✅ `_cached_router_entries` — рекурсивный обход дерева на каждое событие

**Было:** на каждое событие вызывался `self._iter_unique_routers(self.routers)` — полный рекурсивный обход дерева роутеров с накоплением middleware и фильтров каждого уровня.

**Чем чревато отсутствие:** При дереве из 20 роутеров каждое событие выполняет рекурсивный обход. Дерево стабильно после `__ready()` — повторный обход является чистым расточительством. При активном polling'е (1000 событий/сек × 20 роутеров) это 20 000 итераций генератора в секунду вхолостую.

**Решение:** в конце `_prepare_handlers`:

```python
self._cached_router_entries = list(self._iter_unique_routers(self.routers))
```

Все методы (`_iter_and_dispatch_routers`, `handle_raw_response`) используют кеш:

```python
entries = self._cached_router_entries or self._iter_unique_routers(self.routers)
```

---

### 12. ✅ `check_me()` — двойной вызов `_ensure_bot()` и доступ к `._me`

**Было:**

```python
async def check_me(self):
    me = await self._ensure_bot().get_me()
    self._ensure_bot()._me = me   # ← второй вызов + приватный атрибут
    logger_dp.info(...)
```

**Проблемы:**
- `_ensure_bot()` вызывается дважды — метод проверяет `self.bot is not None` и бросает исключение иначе. Два вызова — две потенциальные точки отказа там, где должна быть одна.
- `._me` — обращение к приватному атрибуту нарушает инкапсуляцию и хрупко при рефакторинге имён класса `Bot`.

**Чем чревато отсутствие:** Если `_ensure_bot()` когда-либо приобретёт побочные эффекты (например, логирование предупреждения при повторном вызове), двойной вызов сломает ожидаемое поведение.

**Решение:**

```python
async def check_me(self):
    bot = self._ensure_bot()   # одно обращение, одна точка отказа
    me = await bot.get_me()
    bot.me = me                # публичный атрибут
    logger_dp.info(...)
```

---

### 13. ✅ `start_polling` — монолитный метод (60+ строк, два try/except)

**Было:** `start_polling` содержал всё: запрос `get_updates`, два блока `try/except` на разные классы ошибок, обход событий, логику `skip_updates`, вызов `handle` — более 60 строк в одном методе.

**Чем чревато отсутствие:** Монолитный метод не поддаётся изолированному тестированию. Нельзя проверить: «что происходит при `InvalidToken`», «корректно ли обрабатывается `MaxConnection`», «правильно ли работает `skip_updates`» — без полноценного mock'а всего цикла.

**Решение:** декомпозиция на два приватных метода:

- **`_fetch_updates_once(bot) → dict | None`** — изолирует всю обработку ошибок сети: `AsyncioTimeoutError`, `MaxConnection`, `InvalidToken`, `MaxApiError`, общий `Exception`. Возвращает `None` при recoverable-ошибках, поднимает `InvalidToken` как неrecoverable. Полностью тестируем в изоляции.
- **`_dispatch_fetched_events(events, current_timestamp, *, skip_updates)`** — изолирует логику обработки: маркер, `skip_updates`, ветку `use_create_task`.

`start_polling` сократился до 10 строк:

```python
while self.polling:
    events = await self._fetch_updates_once(bot)
    if events is None:
        continue
    await self._dispatch_fetched_events(events, current_timestamp, skip_updates=skip_updates)
```

---

### 14. ✅ `asyncio.create_task` — утечка ссылок на задачи

**Было:**

```python
if self.use_create_task:
    asyncio.create_task(self.handle(event))
```

**Проблема:** создание задачи без сохранения сильной ссылки — задокументированная ловушка asyncio. Цитата из официальной документации:

> *"Save a reference to the result of this function, to avoid a task disappearing mid-execution. The event loop only keeps weak references to tasks."*

GC может удалить задачу до её завершения — событие молча потеряется без каких-либо исключений или логов.

**Чем чревато отсутствие:** В production под нагрузкой события могут исчезать. Особенно вероятно при коротких событиях и активном GC. Воспроизвести такой баг крайне сложно — он недетерминирован.

**Решение:**

```python
task = asyncio.create_task(self.handle(event))
self._background_tasks.add(task)
task.add_done_callback(self._background_tasks.discard)
```

`_background_tasks: set[asyncio.Task]` хранит сильные ссылки. Callback `discard` освобождает ссылку после завершения, не давая set'у расти бесконечно.

---

### 15. ✅ `stop_polling` — не дожидался фоновых задач

**Было:**

```python
async def stop_polling(self):
    if self.polling:
        self.polling = False
        logger_dp.info("Polling остановлен")
```

**Проблема:** при `use_create_task=True` вызов `stop_polling` немедленно возвращал управление. Все задачи, запущенные через `create_task`, либо продолжали выполняться в фоне, либо отменялись вместе с event loop'ом до завершения.

**Чем чревато отсутствие:** Незавершённые обработчики событий при graceful shutdown — потеря данных, незафиксированные транзакции, неотправленные ответы. Критично для обработчиков платёжной логики или записи в БД.

**Решение:**

```python
async def stop_polling(self):
    if self.polling:
        self.polling = False
        logger_dp.info("Polling остановлен")

    if self._background_tasks:
        logger_dp.info(f"Ожидаю завершения {len(self._background_tasks)} фоновых задач...")
        await asyncio.gather(*self._background_tasks, return_exceptions=True)
        logger_dp.info("Все фоновые задачи завершены")
```

---

### 16. ✅ `_check_router_filters` — усложнённая проверка результата `process_base_filters`

**Было:**

```python
async def _check_router_filters(...) -> dict[str, Any] | Literal[False]:
    if filters and not filter_attrs(event, *filters):
        return False
    if base_filters:
        result = await self.process_base_filters(...)
        if isinstance(result, dict):     # ← необходим из-за нестабильного типа
            return result
        if not result:
            return False
    return {}
```

**Проблема:** лишний `isinstance(result, dict)` порождён нестабильным return type `process_base_filters` (п. 8). После унификации это мертвый код, который замедляет понимание.

**Решение:** после унификации `process_base_filters → dict | None` логика сокращается до прямого `return`:

```python
async def _check_router_filters(...) -> dict[str, Any] | None:
    if filters and not filter_attrs(event, *filters):
        return None
    if base_filters:
        return await self.process_base_filters(event=event, filters=base_filters)
    return {}
```

---

### 17. ✅ `_get_middleware_title` — inline-логика определения имени middleware

**Было:** в блоке обработки исключений в `handle()`:

```python
if hasattr(global_chain, "func"):
    middleware_title = global_chain.func.__class__.__name__
else:
    middleware_title = getattr(global_chain, "__name__", global_chain.__class__.__name__)
```

**Проблема:** inline-логика в `except`-блоке замедляет понимание основного потока. Та же логика потенциально нужна на других уровнях middleware.

**Чем чревато отсутствие:** При необходимости диагностики имени middleware в другом месте — копирование кода. Либо придётся его трогать в блоке `except`, где высок риск внести ошибку.

**Решение:** выделен `@staticmethod _get_middleware_title(chain) -> str` с единственной реализацией:

```python
@staticmethod
def _get_middleware_title(chain: Any) -> str:
    if hasattr(chain, "func"):
        return str(chain.func.__class__.__name__)
    return str(getattr(chain, "__name__", chain.__class__.__name__))
```

---

### 18. ✅ `Handler.func_args` — нестабильный тип, повторное чтение `__annotations__`

**Было:** в `call_handler` при каждом вызове:

```python
func_args = handler.func_event.__annotations__.keys()  # ← чтение __annotations__
kwargs_filtered = {k: v for k, v in data.items() if k in func_args}
# ... chain вызывает call_handler с теми же данными ...

# В call_handler — ТО ЖЕ САМОЕ повторно:
func_args = handler.func_event.__annotations__.keys()
kwargs_filtered = {k: v for k, v in data.items() if k in func_args}
await handler.func_event(event_object, **kwargs_filtered)
```

**Проблема:** `dict_keys` — живой view на `__annotations__`. При использовании декораторов-обёрток (`@wraps`, `@cache`) `__annotations__` может динамически измениться между регистрацией обработчика и его вызовом. Также тип нигде явно не аннотирован, что затрудняет статический анализ.

**Чем чревато отсутствие:** Труднодиагностируемые ошибки при комбинировании декораторов Python с регистраторами хендлеров. `frozenset` фиксирует аннотации на момент регистрации — корректная семантика.

**Решение:** в `_prepare_handlers`:

```python
handler.func_args = frozenset(handler.func_event.__annotations__)
```

`frozenset` обеспечивает O(1) membership test, иммутабельность и явный тип `frozenset[str]`.

---

### 20. ✅ `enrich_event` — монолитная функция 80 строк → три изолированных хелпера

**Было:** единая функция `enrich_event` (~80 строк) смешивала три независимые задачи в одном теле:

```python
async def enrich_event(event_object: Any, bot: Bot) -> Any:
    if not bot.auto_requests:
        return event_object

    # 1. Загрузка chat — но с дублирующим guard'ом
    if hasattr(event_object, "chat_id"):
        is_bot_removed_from_channel = isinstance(event_object, BotRemoved) \
            and getattr(event_object, "is_channel", False)
        if not is_bot_removed_from_channel:
            event_object.chat = await bot.get_chat_by_id(event_object.chat_id)
        else:
            event_object.chat = None

    # 2. from_user — каждый тип события своя ветка, с повторными
    #    "if not hasattr(event_object, 'chat'):" для защиты от двойного вызова
    if isinstance(event_object, (MessageCreated, MessageEdited)):
        if event_object.message.recipient.chat_id is not None:
            if not hasattr(event_object, "chat"):          # ← guard №1
                event_object.chat = await bot.get_chat_by_id(...)
        event_object.from_user = ...

    elif isinstance(event_object, MessageCallback):
        ...
        if not hasattr(event_object, "chat"):              # ← guard №2
            event_object.chat = await bot.get_chat_by_id(...)
        ...

    elif isinstance(event_object, MessageRemoved):
        if not hasattr(event_object, "chat"):              # ← guard №3
            event_object.chat = await bot.get_chat_by_id(...)
        ...

    elif isinstance(event_object, UserRemoved):
        if not hasattr(event_object, "chat"):              # ← guard №4
            event_object.chat = await bot.get_chat_by_id(...)
        ...

    elif isinstance(event_object, UserAdded):              # ← отдельная ветка,
        if not hasattr(event_object, "chat"):              # ←  хотя логика та же
            event_object.chat = await bot.get_chat_by_id(...)
        event_object.from_user = event_object.user

    elif isinstance(event_object, (BotAdded, BotRemoved, BotStarted,
                                    ChatTitleChanged, BotStopped,
                                    DialogCleared, DialogMuted, DialogUnmuted)):
        if not hasattr(event_object, "chat"):              # ← guard №5
            event_object.chat = await bot.get_chat_by_id(...)
        event_object.from_user = event_object.user
    # DialogRemoved — отсутствует! from_user не проставлялся

    # 3. Инъекция bot — в конце того же тела
    if isinstance(event_object, (MessageCreated, MessageEdited, MessageCallback)):
        ...
```

**Проблемы:**

1. **`hasattr(event_object, "chat")` guard повторялся 5 раз** — следствие того, что верхний блок `hasattr(chat_id)` уже мог загрузить чат, а нижние ветки не знали об этом. Защитный паттерн размножился по всем веткам.

2. **Хрупкий `is_bot_removed_from_channel`** — проверка `is_channel` у `BotRemoved` для того, чтобы не делать запрос. При этом `BotRemoved` никогда не имеет доступного `chat_id` — условие было избыточным.

3. **`UserAdded` выделен в отдельную ветку** несмотря на идентичную логику с `BotAdded`, `BotStarted` и ещё семью типами (`from_user = event.user`).

4. **`DialogRemoved` отсутствовал** — `from_user` не проставлялся, молчаливая неполнота.

5. **Тип аннотации `Any`** вместо `UpdateUnion` — статический анализатор не видит атрибутов события.

6. **Невозможно тестировать изолированно** — чтобы проверить только логику загрузки чата для `MessageCallback`, нужно прогнать всю функцию целиком.

**Чем чревато отсутствие:** При добавлении нового типа события (например `ChannelCreated`) нужно было вставить новую ветку `elif` внутрь уже 80-строчной функции, не забыть про `if not hasattr(event_object, "chat"):` guard и не забыть про инъекцию `bot`. Вероятность пропустить один из шагов — высокая.

**Решение:** три изолированных хелпера + константа-кортеж:

```python
_EVENTS_WITH_USER_ATTR = (
    UserAdded, BotAdded, BotRemoved, BotStarted, BotStopped,
    ChatTitleChanged, DialogCleared, DialogMuted, DialogUnmuted, DialogRemoved,
)

async def _resolve_chat(event, bot):
    """Загружает объект чата. Одна ответственность — только chat."""
    if isinstance(event, (DialogRemoved, BotRemoved)):
        return                          # ← вся логика пропуска — здесь
    chat_id = getattr(event, "chat_id", None)
    if chat_id is None and isinstance(event, (MessageCreated, MessageEdited)):
        chat_id = event.message.recipient.chat_id
    elif chat_id is None and isinstance(event, MessageCallback):
        ...
    if chat_id is not None:
        event.chat = await bot.get_chat_by_id(chat_id)

async def _resolve_from_user(event, bot):
    """Определяет отправителя. Никогда не трогает chat."""
    if isinstance(event, (MessageCreated, MessageEdited)):
        event.from_user = getattr(event.message, "sender", None)
    elif isinstance(event, MessageCallback):
        event.from_user = getattr(event.callback, "user", None)
    elif isinstance(event, MessageRemoved):
        ...
    elif isinstance(event, UserRemoved):
        ...
    elif isinstance(event, _EVENTS_WITH_USER_ATTR):   # ← 10 типов одной строкой
        event.from_user = event.user

def _inject_bot(event, bot):
    """Внедряет ссылку на бота. Никогда не трогает chat или from_user."""
    ...
```

Каждый хелпер независимо покрыт тестами в `test_enrich_event.py`:

```
TestResolveChat      — 7 тестов, все ветки _resolve_chat
TestResolveFromUser  — 10 тестов (включая параметризованный на 10 типов)
TestInjectBot        — 5 тестов (message, event, attachments, body=None, message=None)
TestEnrichEvent      — 7 интеграционных тестов сквозного пайплайна
```

---

### 19. ✅ `_iter_routers` — shadowing параметров локальными переменными

**Было:**

```python
def _iter_routers(self, routers, parent_middlewares=None, parent_filters=None, ...):
    parent_middlewares = parent_middlewares or []   # ← параметр переопределяется
    parent_filters = parent_filters or []
    parent_base_filters = parent_base_filters or []
    path = path if path is not None else set()
```

**Проблема:** параметры функции переопределялись одноимёнными локальными переменными. В теле функции `parent_middlewares` — уже локальная переменная. Любая правка, добавляющая ранний `return` или условную ветку ДО строки переопределения, случайно получит `None` вместо `[]`. Это класс ошибок, который ruff/pylint обнаруживают как `W0621`/`PLW0621`.

**Чем чревато отсутствие:** Достаточно добавить одну строку `if something: return router` перед переопределениями — и рекурсивный вызов получит сырые `None`-значения, что приведёт к `AttributeError` при конкатенации `None + list`.

**Решение:** введены чистые локальные переменные без shadowing:

```python
middlewares = parent_middlewares or []
filters = parent_filters or []
base_filters = parent_base_filters or []

if path is None:
    path = set()
```

---

## 📊 Сводная таблица

| #  | Точка                                        | Уровень | Тип                      | Статус |
|----|---------------------------------------------|---------|--------------------------|--------|
| 1  | `handle()` — двухуровневые замыкания        | 🔴 Выс. | Читаемость + GC          | ✅     |
| 2  | `_dispatch_to_router()` — `nonlocal` bool   | 🔴 Выс. | Читаемость + корректность| ✅     |
| 3  | `build_middleware_chain` — без кеша         | 🟡 Сред.| Перформанс               | ✅     |
| 4  | `_execute_handler` + `call_handler`          | 🟡 Сред.| Дублирование             | ✅     |
| 5  | `_check_*` — дублирование фильтрации        | 🟡 Сред.| Дублирование             | ✅     |
| 6  | `enumerate` в `_iter_and_dispatch`           | 🟢 Низк.| Читаемость               | ✅     |
| 7  | `self.contexts` — unbounded dict             | 🟡 Сред.| Память                   | ✅     |
| 8  | `process_base_filters` — return type         | 🟡 Сред.| API контракт             | ✅     |
| 9  | `_prepare_handlers` — отсутствие кешей      | 🔴 Выс. | Перформанс               | ✅     |
| 10 | `_find_matching_handlers` — O(n) поиск      | 🔴 Выс. | Перформанс               | ✅     |
| 11 | `_cached_router_entries` — рекурсия на evt  | 🟡 Сред.| Перформанс               | ✅     |
| 12 | `check_me()` — двойной `_ensure_bot()` + `._me` | 🟢 Низк.| Читаемость + надёжность | ✅     |
| 13 | `start_polling` — монолитный метод          | 🟡 Сред.| Тестируемость            | ✅     |
| 14 | `asyncio.create_task` — утечка ссылок       | 🔴 Выс. | Корректность             | ✅     |
| 15 | `stop_polling` — не ждал фоновые задачи     | 🔴 Выс. | Корректность             | ✅     |
| 16 | `_check_router_filters` — лишняя проверка   | 🟢 Низк.| Упрощение                | ✅     |
| 17 | `_get_middleware_title` — inline в except   | 🟢 Низк.| Читаемость               | ✅     |
| 18 | `Handler.func_args` — нестабильный тип      | 🟢 Низк.| Надёжность               | ✅     |
| 19 | `_iter_routers` — shadowing параметров      | 🟢 Низк.| Читаемость               | ✅     |
| 20 | `enrich_event` — монолит → 3 хелпера        | 🟡 Сред.| Тестируемость + надёжность| ✅    |

---

## 🧪 Покрытие тестами

После рефакторинга всех изменённых модулей написаны изолированные unit-тесты, покрывающие **каждую ветку** кода:

| Модуль / область                    | Что покрыто                                                          |
|-------------------------------------|----------------------------------------------------------------------|
| `dispatcher.py` — `_fetch_updates_once` | Все 5 классов исключений: `AsyncioTimeoutError`, `MaxConnection`, `InvalidToken`, `MaxApiError`, `Exception` |
| `dispatcher.py` — `_dispatch_fetched_events` | `skip_updates`, `use_create_task`, `ClientConnectorError`   |
| `dispatcher.py` — `__get_context`   | LRU-вытеснение при достижении `CONTEXTS_MAX_SIZE`                    |
| `dispatcher.py` — `process_base_filters` | `dict`-результат, falsy-результат (`→ None`), пустой dict          |
| `dispatcher.py` — `_check_handler_match` | states guard, MagicFilter pass/fail, BaseFilter pass/fail          |
| `dispatcher.py` — `stop_polling`    | Ожидание фоновых задач, пустой `_background_tasks`                   |
| `utils/updates.py` — `_resolve_chat` | Все ветки: `DialogRemoved`, `BotRemoved`, top-level `chat_id`, fallback к `recipient.chat_id`, `message=None` |
| `utils/updates.py` — `_resolve_from_user` | Все типы: `MessageCreated`, `MessageCallback`, `MessageRemoved` (CHAT/DIALOG), `UserRemoved` (с/без `admin_id`), 10 типов из `_EVENTS_WITH_USER_ATTR` |
| `utils/updates.py` — `_inject_bot`  | message, event, attachments, `body=None`, `message=None`            |
| `utils/updates.py` — `enrich_event` | Сквозной пайплайн для 12 типов событий + `auto_requests=False`      |

**Итог:** 493 теста, все проходят ✅

---

## ⚡ Результат

| Метрика                     | До                                | После                          |
|-----------------------------|-----------------------------------|--------------------------------|
| Уровней вложения замыканий  | 2 (handle → _process → _handlers) | 0 (плоские методы)             |
| Аллокаций на событие        | 3+ замыкания                      | 0 замыканий                    |
| Построений mw-цепочки       | 3 × `partial`/evt                 | 1 (router) + кеш               |
| Поиск хендлеров             | O(n) linear scan                  | O(1) dict lookup               |
| Обход дерева роутеров       | Рекурсия на каждое событие        | Кеш (1 раз при __ready)        |
| `func_args` вычисление      | 2× при каждом вызове хендлера     | 1× при регистрации (frozenset) |
| Рост `contexts`             | Unbounded                         | LRU (10K max)                  |
| Утечка `create_task`        | ДА (нет сильных ссылок)           | Нет (`_background_tasks` set)  |
| Graceful shutdown           | Не ждал задачи                    | `asyncio.gather` всех задач    |
| Shadowing параметров        | `_iter_routers` перезаписывал 4   | Чистые локальные переменные    |
| Когнитивная сложность       | `nonlocal` × 2, nested × 2       | Плоские методы, явные return   |
| `enrich_event` guards              | `hasattr(chat)` × 5 в одной функции    | Устранены декомпозицией           |
| Пропущенные события                | `DialogRemoved` без `from_user`        | Все типы покрыты                  |
| Тесты                              | —                                      | 493 passed ✅ (100% веток)        |
