### PR TITLE
fix: улучшена безопасность webhook и защита токена

### DIFF
--- a/maxapi/bot.py
+++ b/maxapi/bot.py
@@ -200,6 +200,9 @@ class Bot(BaseConnection):
         self.dispatcher: Dispatcher | None = None
         self._me: User | None = None
 
+    def __repr__(self) -> str:
+        return "Bot(token='***')"
+
     def set_marker_updates(self, marker_updates: int) -> None:
         """
         Устанавливает маркер для получения обновлений.

--- a/maxapi/exceptions/dispatcher.py
+++ b/maxapi/exceptions/dispatcher.py
@@ -25,6 +25,8 @@ class HandlerException(Exception):
             )
         return "HandlerException(" + ", ".join(parts) + ")"
 
+    __repr__ = __str__
+
 
 @dataclass(slots=True)
 class MiddlewareException(Exception):
@@ -46,3 +48,5 @@ class MiddlewareException(Exception):
                 f"cause={self.cause.__class__.__name__}: {self.cause}"
             )
         return "MiddlewareException(" + ", ".join(parts) + ")"
+
+    __repr__ = __str__

--- a/maxapi/methods/subscribe_webhook.py
+++ b/maxapi/methods/subscribe_webhook.py
@@ -1,3 +1,4 @@
+import warnings
 from typing import TYPE_CHECKING, Any, cast
 
 from ..connection.base import BaseConnection
@@ -42,6 +43,13 @@ class SubscribeWebhook(BaseConnection):
         if secret is not None and not (5 <= len(secret) <= 256):
             raise ValueError(
                 "secret не должен быть меньше 5 или больше 256 символов"
+            )
+
+        if not url.startswith("https://"):
+            warnings.warn(
+                "URL вебхука не использует HTTPS. "
+                "Обновления будут передаваться по незашифрованному каналу.",
+                stacklevel=2,
             )
 
         super().__init__()

--- a/maxapi/webhook/base.py
+++ b/maxapi/webhook/base.py
@@ -47,6 +47,12 @@ class BaseMaxWebhook(ABC):
         self.dp = dp
         self.bot = bot
         self.secret = secret
+        if self.secret is None:
+            logger_dp.warning(
+                "Webhook запущен без secret. "
+                "Рекомендуется установить secret для защиты "
+                "от поддельных обновлений."
+            )
 
     async def _startup(self) -> None:
         """Инициализировать диспетчер."""

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -201,6 +201,18 @@ class TestBotMethods:
             # Это нормально, так как мы мокируем весь fetch
 
 
+class TestBotRepr:
+    """Тесты __repr__ для Bot."""
+
+    def test_repr_returns_masked_token(self, bot):
+        """repr(bot) должен возвращать Bot(token='***')."""
+        assert repr(bot) == "Bot(token='***')"
+
+    def test_repr_hides_real_token(self, mock_bot_token, bot):
+        """repr(bot) не должен содержать настоящий токен."""
+        assert mock_bot_token not in repr(bot)
+
+
 class TestBotIntegration:
     """Интеграционные тесты Bot (требуют реальный токен)."""
 

--- a/tests/test_webhook/test_security_warnings.py
+++ b/tests/test_webhook/test_security_warnings.py
@@ -1,0 +1,46 @@
+"""Тесты предупреждений безопасности для webhook-компонентов."""
+
+import logging
+import warnings
+
+import pytest
+from maxapi import Dispatcher
+from maxapi.methods.subscribe_webhook import SubscribeWebhook
+from maxapi.webhook.aiohttp import AiohttpMaxWebhook
+
+
+class DummyBot:
+    pass
+
+
+class TestSubscribeWebhookHttpWarning:
+    """Тесты warnings.warn при HTTP URL в SubscribeWebhook."""
+
+    def test_http_url_emits_warning(self, bot):
+        """При http:// URL должно быть предупреждение."""
+        with pytest.warns(UserWarning, match="не использует HTTPS"):
+            SubscribeWebhook(bot=bot, url="http://example.com/webhook")
+
+    def test_https_url_no_warning(self, bot):
+        """При https:// URL предупреждений быть не должно."""
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            SubscribeWebhook(bot=bot, url="https://example.com/webhook")
+
+
+class TestWebhookSecretNoneWarning:
+    """Тесты logger warning при secret=None в BaseMaxWebhook."""
+
+    def test_no_secret_logs_warning(self, caplog):
+        """Без secret должен быть warning в логе."""
+        dp = Dispatcher()
+        with caplog.at_level(logging.WARNING):
+            AiohttpMaxWebhook(dp=dp, bot=DummyBot(), secret=None)
+        assert any("без secret" in r.message for r in caplog.records)
+
+    def test_with_secret_no_warning(self, caplog):
+        """С secret предупреждения быть не должно."""
+        dp = Dispatcher()
+        with caplog.at_level(logging.WARNING):
+            AiohttpMaxWebhook(dp=dp, bot=DummyBot(), secret="my-secret")
+        assert not any("без secret" in r.message for r in caplog.records)


### PR DESCRIPTION
## Описание

### 1. Предупреждение при запуске webhook без secret

**Файл:** `webhook/base.py`

При `secret=None` (по умолчанию) webhook-эндпоинт принимает запросы без какой-либо аутентификации. Злоумышленник, знающий URL, может отправлять поддельные обновления. Добавлен `logger_dp.warning` при запуске без secret.

### 2. Исключения больше не утекают `memory_context` через `repr()`

**Файл:** `exceptions/dispatcher.py`

`HandlerException` и `MiddlewareException` — dataclass с автогенерированным `__repr__`, который выводил все поля, включая `memory_context` с FSM-данными пользователей. В `dispatcher.py:986` использовался `%r` → полный контекст попадал в логи. Добавлен `__repr__ = __str__`, который выводит только ключи.

### 3. Предупреждение при подписке webhook на HTTP (не HTTPS)

**Файл:** `methods/subscribe_webhook.py`

URL вебхука не проверялся на использование HTTPS. Разработчик мог случайно подписать бота на HTTP-эндпоинт — обновления (включая сообщения пользователей) передавались бы по незашифрованному каналу. Добавлен `warnings.warn`.

### 4. `Bot.__repr__` с маскировкой токена

**Файл:** `bot.py`

Добавлен `__repr__`, возвращающий `Bot(token='***')`, для защиты от случайной утечки токена в логах и трейсбеках.

## Тестирование

- Все существующие тесты проходят
- ruff check / ruff format — без замечаний