### PR TITLE
feat: fetch для user и chat при auto_requests=False

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -191,9 +191,12 @@ if __name__ == '__main__':
 chat = await event.fetch_chat()
 from_user = await event.fetch_from_user()
 
-# или через сами ref-объекты
-chat = await event.chat.fetch() if event.chat else None
-from_user = await event.from_user.fetch() if event.from_user else None
+# или через сами ref-объекты (проверяйте через is not None,
+# т.к. pending lazy ref является falsy)
+chat = await event.chat.fetch() if event.chat is not None else None
+from_user = (
+    await event.from_user.fetch() if event.from_user is not None else None
+)
 ```
 
 ## MagicFilter

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -99,13 +99,14 @@ async def hello(event: MessageCreated):
 
 @dp.bot_added()
 async def bot_added(event: BotAdded):
-    if event.chat is None:
+    chat = await event.fetch_chat()
+    if chat is None:
         logging.info('Не удалось получить chat, возможно отключен auto_requests!')
         return
     
     await bot.send_message(
         chat_id=event.chat_id,
-        text=f'Привет чат {event.chat.title}!'
+        text=f'Привет чат {chat.title}!'
     )
 
 
@@ -149,7 +150,8 @@ async def message_edited(event: MessageEdited):
 
 @dp.user_removed()
 async def user_removed(event: UserRemoved):
-    if event.from_user is None:
+    from_user = await event.fetch_from_user()
+    if from_user is None:
         return await bot.send_message(
             chat_id=event.chat_id,
             text=f'Неизвестный кикнул {event.user.first_name} 😢'
@@ -157,13 +159,14 @@ async def user_removed(event: UserRemoved):
         
     await bot.send_message(
         chat_id=event.chat_id,
-        text=f'{event.from_user.first_name} кикнул {event.user.first_name} 😢'
+        text=f'{from_user.first_name} кикнул {event.user.first_name} 😢'
     )
 
 
 @dp.user_added()
 async def user_added(event: UserAdded):
-    if event.chat is None:
+    chat = await event.fetch_chat()
+    if chat is None:
         return await bot.send_message(
             chat_id=event.chat_id,
             text=f'Чат приветствует вас, {event.user.first_name}!'
@@ -171,7 +174,7 @@ async def user_added(event: UserAdded):
         
     await bot.send_message(
         chat_id=event.chat_id,
-        text=f'Чат "{event.chat.title}" приветствует вас, {event.user.first_name}!'
+        text=f'Чат "{chat.title}" приветствует вас, {event.user.first_name}!'
     )
 
 
@@ -184,19 +187,22 @@ if __name__ == '__main__':
 ```
 
 Если бот создан с `auto_requests=False`, то `event.chat` и
-`event.from_user` могут быть lazy ref. В этом режиме запрашивайте их
-явно:
+`event.from_user` могут быть не загружены автоматически. Чтобы безопасно
+получить их независимо от режима, используйте явный fetch:
 
 ```python
 chat = await event.fetch_chat()
 from_user = await event.fetch_from_user()
+```
 
-# или через сами ref-объекты (проверяйте через is not None,
-# т.к. pending lazy ref является falsy)
-chat = await event.chat.fetch() if event.chat is not None else None
-from_user = (
-    await event.from_user.fetch() if event.from_user is not None else None
-)
+После этого работайте уже с локальными переменными:
+
+```python
+if chat is not None:
+    print(chat.title)
+
+if from_user is not None:
+    print(from_user.first_name)
 ```
 
 ## MagicFilter
@@ -503,9 +509,15 @@ async def get_ids_from_forward(event: MessageCreated):
 
 @dp.message_created()
 async def get_ids(event: MessageCreated):
+    from_user = await event.fetch_from_user()
+    chat = await event.fetch_chat()
+
+    if from_user is None or chat is None:
+        return
+
     text = (
-        f'Ваш ID: <b>{event.from_user.user_id}</b>\n'
-        f'ID этого чата: <b>{event.chat.chat_id}</b>'
+        f'Ваш ID: <b>{from_user.user_id}</b>\n'
+        f'ID этого чата: <b>{chat.chat_id}</b>'
     )
     await event.message.answer(text, format=Format.HTML)
 
@@ -543,11 +555,12 @@ class FilterChat(BaseFilter):
     """
     
     async def __call__(self, event: UpdateUnion):
-        
-        if event.chat is None:
+
+        chat = await event.fetch_chat()
+        if chat is None:
             return False
-        
-        return event.chat == 'Test'
+
+        return chat.title == 'Test'
 
 
 @dp.message_created(CommandStart(), FilterChat())

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -99,7 +99,7 @@ async def hello(event: MessageCreated):
 
 @dp.bot_added()
 async def bot_added(event: BotAdded):
-    if not event.chat:
+    if event.chat is None:
         logging.info('Не удалось получить chat, возможно отключен auto_requests!')
         return
     
@@ -149,7 +149,7 @@ async def message_edited(event: MessageEdited):
 
 @dp.user_removed()
 async def user_removed(event: UserRemoved):
-    if not event.from_user:
+    if event.from_user is None:
         return await bot.send_message(
             chat_id=event.chat_id,
             text=f'Неизвестный кикнул {event.user.first_name} 😢'
@@ -163,7 +163,7 @@ async def user_removed(event: UserRemoved):
 
 @dp.user_added()
 async def user_added(event: UserAdded):
-    if not event.chat:
+    if event.chat is None:
         return await bot.send_message(
             chat_id=event.chat_id,
             text=f'Чат приветствует вас, {event.user.first_name}!'
@@ -478,7 +478,7 @@ class FilterChat(BaseFilter):
     
     async def __call__(self, event: UpdateUnion):
         
-        if not event.chat:
+        if event.chat is None:
             return False
         
         return event.chat == 'Test'

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -183,6 +183,19 @@ if __name__ == '__main__':
     asyncio.run(main())
 ```
 
+Если бот создан с `auto_requests=False`, то `event.chat` и
+`event.from_user` могут быть lazy ref. В этом режиме запрашивайте их
+явно:
+
+```python
+chat = await event.fetch_chat()
+from_user = await event.fetch_from_user()
+
+# или через сами ref-объекты
+chat = await event.chat.fetch() if event.chat else None
+from_user = await event.from_user.fetch() if event.from_user else None
+```
+
 ## MagicFilter
 
 Использование MagicFilter для гибкой фильтрации сообщений:

--- a/maxapi/bot.py
+++ b/maxapi/bot.py
@@ -125,6 +125,8 @@ class Bot(BaseConnection):
                 будет генерировать превью для ссылок в тексте сообщений.
             auto_requests (bool): Автоматическое заполнение
                 chat/from_user через API (по умолчанию True).
+                При False в event.chat/event.from_user остаются lazy ref
+                c ручным await .fetch().
             default_connection (Optional[DefaultConnectionProperties]):
                 Настройки соединения.
             after_input_media_delay (Optional[float]): Задержка после

--- a/maxapi/bot.py
+++ b/maxapi/bot.py
@@ -125,8 +125,11 @@ class Bot(BaseConnection):
                 будет генерировать превью для ссылок в тексте сообщений.
             auto_requests (bool): Автоматическое заполнение
                 chat/from_user через API (по умолчанию True).
-                При False в event.chat/event.from_user остаются lazy ref
-                с ручным await .fetch().
+                При False дополнительные запросы для их заполнения не
+                выполняются: в event.chat/event.from_user могут
+                оставаться lazy ref с ручным await .fetch(), либо эти
+                поля уже могут быть заполнены данными из payload
+                события.
             default_connection (Optional[DefaultConnectionProperties]):
                 Настройки соединения.
             after_input_media_delay (Optional[float]): Задержка после

--- a/maxapi/bot.py
+++ b/maxapi/bot.py
@@ -126,7 +126,7 @@ class Bot(BaseConnection):
             auto_requests (bool): Автоматическое заполнение
                 chat/from_user через API (по умолчанию True).
                 При False в event.chat/event.from_user остаются lazy ref
-                c ручным await .fetch().
+                с ручным await .fetch().
             default_connection (Optional[DefaultConnectionProperties]):
                 Настройки соединения.
             after_input_media_delay (Optional[float]): Задержка после

--- a/maxapi/types/__init__.py
+++ b/maxapi/types/__init__.py
@@ -18,6 +18,7 @@ from ..types.attachments.buttons.request_geo_location_button import (
 )
 from ..types.attachments.image import PhotoAttachmentRequestPayload
 from ..types.command import BotCommand
+from ..types.fetchable import ChatRef, FromUserRef
 from ..types.message import Message, NewMessageLink
 from ..types.updates import UpdateUnion
 from ..types.updates.bot_added import BotAdded
@@ -48,6 +49,7 @@ __all__ = [
     "ButtonsPayload",
     "CallbackButton",
     "ChatButton",
+    "ChatRef",
     "ChatTitleChanged",
     "Command",
     "CommandStart",
@@ -56,6 +58,7 @@ __all__ = [
     "DialogMuted",
     "DialogRemoved",
     "DialogUnmuted",
+    "FromUserRef",
     "InputMedia",
     "InputMediaBuffer",
     "LinkButton",

--- a/maxapi/types/attachments/video.py
+++ b/maxapi/types/attachments/video.py
@@ -67,4 +67,4 @@ class Video(Attachment):
     bot: Any | None = Field(default=None, exclude=True)  # pyright: ignore[reportRedeclaration]
 
     if TYPE_CHECKING:
-        bot: "Bot" | None  # type: ignore
+        bot: Bot | None  # type: ignore

--- a/maxapi/types/chats.py
+++ b/maxapi/types/chats.py
@@ -11,6 +11,7 @@ from pydantic import (
 from ..enums.chat_permission import ChatPermission
 from ..enums.chat_status import ChatStatus
 from ..enums.chat_type import ChatType
+from ..types.fetchable import FetchableMixin
 from ..types.message import Message
 from ..types.users import User
 from ..utils.time import from_ms, to_ms
@@ -27,7 +28,7 @@ class Icon(BaseModel):
     url: str
 
 
-class Chat(BaseModel):
+class Chat(FetchableMixin, BaseModel):
     """
     Модель чата.
 

--- a/maxapi/types/fetchable.py
+++ b/maxapi/types/fetchable.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from typing import TYPE_CHECKING, Any, Generic, TypeVar, cast
 
 from .bot_mixin import BotMixin
@@ -43,14 +44,17 @@ class LazyRef(BotMixin, Generic[ResolvedValue]):
         self._setter = setter
         self._description = description
         self._resolved: ResolvedValue | None | object = _UNSET
+        self._fetch_lock = asyncio.Lock()
 
     async def fetch(self) -> ResolvedValue | None:
         """Загрузить значение и закешировать результат."""
 
         if self._resolved is _UNSET:
-            value = await self._fetcher()
-            self._resolved = value
-            self._setter(value)
+            async with self._fetch_lock:
+                if self._resolved is _UNSET:
+                    value = await self._fetcher()
+                    self._resolved = value
+                    self._setter(value)
 
         return cast(ResolvedValue | None, self._resolved)
 

--- a/maxapi/types/fetchable.py
+++ b/maxapi/types/fetchable.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Generic, TypeVar, cast
+
+from .bot_mixin import BotMixin
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+
+    from typing_extensions import Self
+
+    from ..bot import Bot
+    from .chats import Chat, ChatMember
+    from .users import User
+
+ResolvedValue = TypeVar("ResolvedValue")
+
+_UNSET = object()
+
+
+class FetchableMixin:
+    """Миксин для объектов, которые уже содержат все данные."""
+
+    async def fetch(self) -> Self:
+        """Вернуть текущий объект без дополнительных запросов."""
+
+        return self
+
+
+class LazyRef(BotMixin, Generic[ResolvedValue]):
+    """Ленивая ссылка на сущность, которая подгружается по запросу."""
+
+    def __init__(
+        self,
+        *,
+        bot: Bot,
+        fetcher: Callable[[], Awaitable[ResolvedValue | None]],
+        setter: Callable[[ResolvedValue | None], None],
+        description: str,
+    ) -> None:
+        self.bot = bot
+        self._fetcher = fetcher
+        self._setter = setter
+        self._description = description
+        self._resolved: ResolvedValue | None | object = _UNSET
+
+    async def fetch(self) -> ResolvedValue | None:
+        """Загрузить значение и закешировать результат."""
+
+        if self._resolved is _UNSET:
+            value = await self._fetcher()
+            self._resolved = value
+            self._setter(value)
+
+        return cast(ResolvedValue | None, self._resolved)
+
+    def __bool__(self) -> bool:
+        if self._resolved is _UNSET:
+            return False
+        return bool(self._resolved)
+
+    def __getattr__(self, name: str) -> Any:
+        if self._resolved is _UNSET:
+            msg = (
+                f"{self._description} еще не загружен. "
+                "Вызовите await ref.fetch()."
+            )
+            raise AttributeError(msg)
+
+        return getattr(self._resolved, name)
+
+    def __repr__(self) -> str:
+        state = "resolved" if self._resolved is not _UNSET else "pending"
+        return f"{self.__class__.__name__}({self._description}, {state})"
+
+
+class ChatRef(LazyRef["Chat"]):
+    """Ленивая ссылка на чат события."""
+
+    def __init__(
+        self,
+        *,
+        bot: Bot,
+        chat_id: int,
+        setter: Callable[[Chat | None], None],
+    ) -> None:
+        self.chat_id = chat_id
+        super().__init__(
+            bot=bot,
+            fetcher=lambda: bot.get_chat_by_id(chat_id),
+            setter=setter,
+            description=f"chat_id={chat_id}",
+        )
+
+
+class FromUserRef(LazyRef["User | ChatMember | Chat"]):
+    """Ленивая ссылка на отправителя/инициатора события."""
+
+    def __init__(
+        self,
+        *,
+        bot: Bot,
+        fetcher: Callable[[], Awaitable[User | ChatMember | Chat | None]],
+        setter: Callable[[User | ChatMember | Chat | None], None],
+        chat_id: int | None = None,
+        user_id: int | None = None,
+    ) -> None:
+        self.chat_id = chat_id
+        self.user_id = user_id
+        description = f"chat_id={chat_id}, user_id={user_id}"
+        super().__init__(
+            bot=bot,
+            fetcher=fetcher,
+            setter=setter,
+            description=description,
+        )

--- a/maxapi/types/updates/base_update.py
+++ b/maxapi/types/updates/base_update.py
@@ -10,7 +10,7 @@ from ...types.fetchable import LazyRef
 
 if TYPE_CHECKING:
     from ...bot import Bot
-    from ...types.chats import Chat
+    from ...types.chats import Chat, ChatMember
     from ...types.users import User
 
 
@@ -32,33 +32,36 @@ class BaseUpdate(BaseModel, BotMixin):
 
     if TYPE_CHECKING:
         bot: Bot | None  # type: ignore
-        from_user: User | None  # type: ignore
+        from_user: User | ChatMember | Chat | None  # type: ignore
         chat: Chat | None  # type: ignore
 
     model_config = ConfigDict(
         arbitrary_types_allowed=True,
     )
 
-    async def fetch_chat(self) -> Any | None:
+    async def _fetch_field(self, field_name: str) -> Any | None:
+        """Явно получить поле события, если в нем лежит lazy ref."""
+
+        try:
+            value = getattr(self, field_name)
+        except AttributeError as exc:
+            msg = f"{self.__class__.__name__} has no field {field_name!r}"
+            raise AttributeError(msg) from exc
+
+        if value is None:
+            return None
+
+        if isinstance(value, LazyRef):
+            return await value.fetch()
+
+        return value
+
+    async def fetch_chat(self) -> Chat | None:
         """Явно получить chat для события, если доступен lazy fetch."""
 
-        chat = self.chat
-        if chat is None:
-            return None
+        return await self._fetch_field("chat")
 
-        if isinstance(chat, LazyRef):
-            return await chat.fetch()
-
-        return chat
-
-    async def fetch_from_user(self) -> Any | None:
+    async def fetch_from_user(self) -> User | ChatMember | Chat | None:
         """Явно получить from_user для события, если доступен lazy fetch."""
 
-        from_user = self.from_user
-        if from_user is None:
-            return None
-
-        if isinstance(from_user, LazyRef):
-            return await from_user.fetch()
-
-        return from_user
+        return await self._fetch_field("from_user")

--- a/maxapi/types/updates/base_update.py
+++ b/maxapi/types/updates/base_update.py
@@ -37,3 +37,29 @@ class BaseUpdate(BaseModel, BotMixin):
     model_config = ConfigDict(
         arbitrary_types_allowed=True,
     )
+
+    async def fetch_chat(self) -> Any | None:
+        """Явно получить chat для события, если доступен lazy fetch."""
+
+        chat = self.chat
+        if chat is None:
+            return None
+
+        fetch = getattr(chat, "fetch", None)
+        if callable(fetch):
+            return await fetch()
+
+        return chat
+
+    async def fetch_from_user(self) -> Any | None:
+        """Явно получить from_user для события, если доступен lazy fetch."""
+
+        from_user = self.from_user
+        if from_user is None:
+            return None
+
+        fetch = getattr(from_user, "fetch", None)
+        if callable(fetch):
+            return await fetch()
+
+        return from_user

--- a/maxapi/types/updates/base_update.py
+++ b/maxapi/types/updates/base_update.py
@@ -6,6 +6,7 @@ from pydantic import BaseModel, ConfigDict, Field
 
 from ...enums.update import UpdateType
 from ...types.bot_mixin import BotMixin
+from ...types.fetchable import LazyRef
 
 if TYPE_CHECKING:
     from ...bot import Bot
@@ -45,9 +46,8 @@ class BaseUpdate(BaseModel, BotMixin):
         if chat is None:
             return None
 
-        fetch = getattr(chat, "fetch", None)
-        if callable(fetch):
-            return await fetch()
+        if isinstance(chat, LazyRef):
+            return await chat.fetch()
 
         return chat
 
@@ -58,8 +58,7 @@ class BaseUpdate(BaseModel, BotMixin):
         if from_user is None:
             return None
 
-        fetch = getattr(from_user, "fetch", None)
-        if callable(fetch):
-            return await fetch()
+        if isinstance(from_user, LazyRef):
+            return await from_user.fetch()
 
         return from_user

--- a/maxapi/types/users.py
+++ b/maxapi/types/users.py
@@ -2,10 +2,11 @@ from pydantic import BaseModel
 
 from ..enums.chat_permission import ChatPermission
 from ..types.command import BotCommand
+from ..types.fetchable import FetchableMixin
 from ..utils.formatting import UserMention
 
 
-class User(BaseModel):
+class User(FetchableMixin, BaseModel):
     """
     Модель пользователя.
 

--- a/maxapi/utils/updates.py
+++ b/maxapi/utils/updates.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING, Any
 
 from ..enums.chat_type import ChatType
+from ..exceptions.max import MaxApiError, MaxConnection
 from ..types.fetchable import ChatRef, FromUserRef
 from ..types.updates.bot_added import BotAdded
 from ..types.updates.bot_removed import BotRemoved
@@ -23,6 +25,8 @@ from ..types.updates.user_removed import UserRemoved
 if TYPE_CHECKING:
     from ..bot import Bot
     from ..types.updates import UpdateUnion
+
+logger = logging.getLogger(__name__)
 
 _EVENTS_WITH_USER_ATTR = (
     UserAdded,
@@ -103,9 +107,22 @@ async def _resolve_from_user(event: UpdateUnion, bot: Bot) -> None:
             event.from_user = event.chat
 
     elif isinstance(event, UserRemoved) and event.admin_id:
-        event.from_user = await bot.get_chat_member(
-            chat_id=event.chat_id, user_id=event.admin_id
-        )
+        try:
+            event.from_user = await bot.get_chat_member(
+                chat_id=event.chat_id,
+                user_id=event.admin_id,
+            )
+        except MaxApiError as exc:
+            logger.warning(
+                "Не удалось получить участника чата: code=%s chat_id=%s",
+                exc.code,
+                event.chat_id,
+            )
+        except MaxConnection:
+            logger.warning(
+                "get_chat_member: connection error chat_id=%s",
+                event.chat_id,
+            )
 
 
 def _inject_bot(event: UpdateUnion, bot: Bot) -> None:

--- a/maxapi/utils/updates.py
+++ b/maxapi/utils/updates.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from ..enums.chat_type import ChatType
+from ..types.fetchable import ChatRef, FromUserRef
 from ..types.updates.bot_added import BotAdded
 from ..types.updates.bot_removed import BotRemoved
 from ..types.updates.bot_started import BotStarted
@@ -37,11 +38,8 @@ _EVENTS_WITH_USER_ATTR = (
 )
 
 
-async def _resolve_chat(event: UpdateUnion, bot: Bot) -> None:
-    """Загружает объект чата для события."""
-
-    if isinstance(event, (DialogRemoved, BotRemoved)):
-        return
+def _extract_chat_id(event: UpdateUnion) -> int | None:
+    """Вытащить chat_id из события или вложенного message."""
 
     chat_id = getattr(event, "chat_id", None)
 
@@ -53,20 +51,50 @@ async def _resolve_chat(event: UpdateUnion, bot: Bot) -> None:
         if message is not None:
             chat_id = message.recipient.chat_id
 
+    return chat_id
+
+
+def _can_resolve_chat(event: UpdateUnion) -> bool:
+    """Проверить, допустима ли загрузка chat для данного события."""
+
+    return not isinstance(event, (DialogRemoved, BotRemoved))
+
+
+async def _resolve_chat(event: UpdateUnion, bot: Bot) -> None:
+    """Загружает объект чата для события."""
+
+    if not _can_resolve_chat(event):
+        return
+
+    chat_id = _extract_chat_id(event)
     if chat_id is not None:
         event.chat = await bot.get_chat_by_id(chat_id)
+
+
+def _resolve_from_user_from_payload(event: UpdateUnion) -> Any | None:
+    """Определяет from_user без дополнительных API-запросов."""
+
+    if isinstance(event, (MessageCreated, MessageEdited)):
+        return getattr(event.message, "sender", None)
+
+    if isinstance(event, MessageCallback):
+        return getattr(event.callback, "user", None)
+
+    if isinstance(event, _EVENTS_WITH_USER_ATTR):
+        return event.user
+
+    return None
 
 
 async def _resolve_from_user(event: UpdateUnion, bot: Bot) -> None:
     """Определяет отправителя события."""
 
-    if isinstance(event, (MessageCreated, MessageEdited)):
-        event.from_user = getattr(event.message, "sender", None)
+    payload_from_user = _resolve_from_user_from_payload(event)
+    if payload_from_user is not None:
+        event.from_user = payload_from_user
+        return
 
-    elif isinstance(event, MessageCallback):
-        event.from_user = getattr(event.callback, "user", None)
-
-    elif isinstance(event, MessageRemoved):
+    if isinstance(event, MessageRemoved):
         if event.chat and event.chat.type == ChatType.CHAT:
             event.from_user = await bot.get_chat_member(
                 chat_id=event.chat_id, user_id=event.user_id
@@ -74,14 +102,10 @@ async def _resolve_from_user(event: UpdateUnion, bot: Bot) -> None:
         elif event.chat and event.chat.type == ChatType.DIALOG:
             event.from_user = event.chat
 
-    elif isinstance(event, UserRemoved):
-        if event.admin_id:
-            event.from_user = await bot.get_chat_member(
-                chat_id=event.chat_id, user_id=event.admin_id
-            )
-
-    elif isinstance(event, _EVENTS_WITH_USER_ATTR):
-        event.from_user = event.user
+    elif isinstance(event, UserRemoved) and event.admin_id:
+        event.from_user = await bot.get_chat_member(
+            chat_id=event.chat_id, user_id=event.admin_id
+        )
 
 
 def _inject_bot(event: UpdateUnion, bot: Bot) -> None:
@@ -100,6 +124,90 @@ def _inject_bot(event: UpdateUnion, bot: Bot) -> None:
         event.bot = bot
 
 
+async def _fetch_from_user_for_message_removed(
+    event: MessageRemoved, bot: Bot
+) -> Any | None:
+    """Разрешить from_user для MessageRemoved по требованию."""
+
+    chat = await event.fetch_chat()
+    if chat is None:
+        return None
+
+    if chat.type == ChatType.CHAT:
+        return await bot.get_chat_member(
+            chat_id=event.chat_id,
+            user_id=event.user_id,
+        )
+
+    if chat.type == ChatType.DIALOG:
+        return chat
+
+    return None
+
+
+def _build_chat_ref(event: UpdateUnion, bot: Bot) -> ChatRef | None:
+    """Построить lazy ref для chat, если его можно загрузить вручную."""
+
+    if not _can_resolve_chat(event):
+        return None
+
+    chat_id = _extract_chat_id(event)
+    if chat_id is None:
+        return None
+
+    return ChatRef(
+        bot=bot,
+        chat_id=chat_id,
+        setter=lambda value: setattr(event, "chat", value),
+    )
+
+
+def _build_from_user_value(event: UpdateUnion, bot: Bot) -> Any | None:
+    """Построить from_user из payload или lazy ref без сетевого запроса."""
+
+    payload_from_user = _resolve_from_user_from_payload(event)
+    if payload_from_user is not None:
+        return payload_from_user
+
+    if isinstance(event, MessageRemoved):
+        return FromUserRef(
+            bot=bot,
+            fetcher=lambda: _fetch_from_user_for_message_removed(event, bot),
+            setter=lambda value: setattr(event, "from_user", value),
+            chat_id=event.chat_id,
+            user_id=event.user_id,
+        )
+
+    if isinstance(event, UserRemoved) and event.admin_id:
+        admin_id = event.admin_id
+        return FromUserRef(
+            bot=bot,
+            fetcher=lambda: bot.get_chat_member(
+                chat_id=event.chat_id,
+                user_id=admin_id,
+            ),
+            setter=lambda value: setattr(event, "from_user", value),
+            chat_id=event.chat_id,
+            user_id=admin_id,
+        )
+
+    return None
+
+
+def _attach_lazy_refs(event: UpdateUnion, bot: Bot) -> None:
+    """Подготовить ручной fetch для chat/from_user без автозапросов."""
+
+    if getattr(event, "chat", None) is None:
+        chat_ref = _build_chat_ref(event, bot)
+        if chat_ref is not None:
+            event.chat = chat_ref
+
+    if getattr(event, "from_user", None) is None:
+        from_user = _build_from_user_value(event, bot)
+        if from_user is not None:
+            event.from_user = from_user
+
+
 async def enrich_event(event_object: UpdateUnion, bot: Bot) -> UpdateUnion:
     """
     Дополняет объект события данными чата, пользователя и ссылкой на бота.
@@ -112,11 +220,13 @@ async def enrich_event(event_object: UpdateUnion, bot: Bot) -> UpdateUnion:
         UpdateUnion: Обновлённый объект события.
     """
 
+    _inject_bot(event_object, bot)
+
     if not bot.auto_requests:
+        _attach_lazy_refs(event_object, bot)
         return event_object
 
     await _resolve_chat(event_object, bot)
     await _resolve_from_user(event_object, bot)
-    _inject_bot(event_object, bot)
 
     return event_object

--- a/tests/test_enrich_event.py
+++ b/tests/test_enrich_event.py
@@ -350,6 +350,17 @@ class TestEnrichEvent:
             fixture_message_created.message.recipient.chat_id
         )
 
+    async def test_auto_requests_false_message_created_without_chat_id(
+        self, bot, fixture_message_created
+    ):
+        """Без chat_id lazy chat ref не создаётся."""
+        fixture_message_created.message.recipient.chat_id = None
+        bot.auto_requests = False
+
+        result = await enrich_event(fixture_message_created, bot)
+
+        assert result.chat is None
+
     async def test_auto_requests_false_message_created_from_user_fetch_is_noop(
         self, bot, fixture_message_created
     ):
@@ -428,6 +439,80 @@ class TestEnrichEvent:
             chat_id=fixture_user_removed.chat_id,
             user_id=fixture_user_removed.admin_id,
         )
+
+    async def test_auto_requests_false_message_removed_dialog_fetch(
+        self,
+        bot,
+        fixture_message_removed,
+    ):
+        """Lazy fetch должен вернуть chat для DIALOG без get_chat_member."""
+        fake_chat = _make_chat(ChatType.DIALOG)
+        bot.auto_requests = False
+        bot.get_chat_by_id = AsyncMock(return_value=fake_chat)
+        bot.get_chat_member = AsyncMock()
+
+        result = await enrich_event(fixture_message_removed, bot)
+        fetched_from_user = await result.from_user.fetch()
+
+        assert fetched_from_user is fake_chat
+        assert result.from_user is fake_chat
+        bot.get_chat_member.assert_not_called()
+
+    async def test_auto_requests_false_message_removed_without_chat(
+        self,
+        bot,
+        fixture_message_removed,
+    ):
+        """Если chat не найден, lazy fetch from_user тоже возвращает None."""
+        bot.auto_requests = False
+        bot.get_chat_by_id = AsyncMock(return_value=None)
+        bot.get_chat_member = AsyncMock()
+
+        result = await enrich_event(fixture_message_removed, bot)
+        fetched_from_user = await result.from_user.fetch()
+
+        assert fetched_from_user is None
+        assert result.from_user is None
+        bot.get_chat_member.assert_not_called()
+
+    async def test_auto_requests_false_message_removed_unknown_chat_type(
+        self, bot, fixture_message_removed
+    ):
+        """Неизвестный тип чата даёт None вместо from_user."""
+        fake_chat = _make_chat()
+        fake_chat.type = object()
+        bot.auto_requests = False
+        bot.get_chat_by_id = AsyncMock(return_value=fake_chat)
+        bot.get_chat_member = AsyncMock()
+
+        result = await enrich_event(fixture_message_removed, bot)
+        fetched_from_user = await result.from_user.fetch()
+
+        assert fetched_from_user is None
+        assert result.from_user is None
+        bot.get_chat_member.assert_not_called()
+
+    async def test_auto_requests_false_user_removed_without_admin_keeps_none(
+        self, bot, fixture_user_removed
+    ):
+        """Без admin_id from_user не синтезируется даже как lazy ref."""
+        fixture_user_removed.admin_id = None
+        bot.auto_requests = False
+
+        result = await enrich_event(fixture_user_removed, bot)
+
+        assert result.from_user is None
+
+    async def test_auto_requests_false_bot_removed_keeps_chat_none(
+        self, bot, fixture_bot_removed
+    ):
+        """BotRemoved не должен получать lazy chat ref."""
+        bot.auto_requests = False
+
+        result = await enrich_event(fixture_bot_removed, bot)
+
+        assert result.chat is None
+        assert result.from_user is fixture_bot_removed.user
 
     async def test_full_pipeline_message_created(
         self, bot, fixture_message_created

--- a/tests/test_enrich_event.py
+++ b/tests/test_enrich_event.py
@@ -11,6 +11,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from maxapi.enums.chat_type import ChatType
+from maxapi.exceptions.max import MaxApiError, MaxConnection
 from maxapi.types.fetchable import ChatRef, FromUserRef
 from maxapi.utils.updates import (
     _inject_bot,
@@ -243,6 +244,34 @@ class TestResolveFromUser:
 
         bot.get_chat_member.assert_not_called()
         assert fixture_user_removed.from_user is None
+
+    async def test_user_removed_api_error_logs_and_keeps_from_user_none(
+        self, bot, fixture_user_removed, caplog
+    ):
+        fixture_user_removed.admin_id = 9999
+        bot.get_chat_member = AsyncMock(
+            side_effect=MaxApiError(403, "forbidden")
+        )
+
+        with caplog.at_level("WARNING", logger="maxapi.utils.updates"):
+            await _resolve_from_user(fixture_user_removed, bot)
+
+        assert fixture_user_removed.from_user is None
+        assert "Не удалось получить участника чата" in caplog.text
+
+    async def test_user_removed_connection_error_logs_and_keeps_from_user_none(
+        self, bot, fixture_user_removed, caplog
+    ):
+        fixture_user_removed.admin_id = 9999
+        bot.get_chat_member = AsyncMock(
+            side_effect=MaxConnection("conn error")
+        )
+
+        with caplog.at_level("WARNING", logger="maxapi.utils.updates"):
+            await _resolve_from_user(fixture_user_removed, bot)
+
+        assert fixture_user_removed.from_user is None
+        assert "get_chat_member: connection error" in caplog.text
 
     @pytest.mark.parametrize(
         "fixture_name",

--- a/tests/test_enrich_event.py
+++ b/tests/test_enrich_event.py
@@ -11,6 +11,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from maxapi.enums.chat_type import ChatType
+from maxapi.types.fetchable import ChatRef, FromUserRef
 from maxapi.utils.updates import (
     _inject_bot,
     _resolve_chat,
@@ -317,13 +318,116 @@ class TestInjectBot:
 class TestEnrichEvent:
     """Интеграционные тесты для enrich_event."""
 
-    async def test_auto_requests_false_returns_unchanged(
+    async def test_auto_requests_false_keeps_object_and_injects_bot(
         self, bot, fixture_message_created
     ):
-        """auto_requests=False — ранний выход, объект не изменяется."""
+        """auto_requests=False не делает API-запросов, но bot остаётся."""
         bot.auto_requests = False
         result = await enrich_event(fixture_message_created, bot)
         assert result is fixture_message_created
+        assert result.bot is bot
+        assert result.message.bot is bot
+
+    async def test_auto_requests_false_message_created_uses_lazy_chat_ref(
+        self, bot, fixture_message_created
+    ):
+        """Chat загружается только по явному вызову fetch()."""
+        fake_chat = _make_chat(ChatType.DIALOG)
+        bot.auto_requests = False
+        bot.get_chat_by_id = AsyncMock(return_value=fake_chat)
+
+        result = await enrich_event(fixture_message_created, bot)
+
+        assert isinstance(result.chat, ChatRef)
+        assert result.from_user is fixture_message_created.message.sender
+        bot.get_chat_by_id.assert_not_called()
+
+        fetched_chat = await result.chat.fetch()
+
+        assert fetched_chat is fake_chat
+        assert result.chat is fake_chat
+        bot.get_chat_by_id.assert_awaited_once_with(
+            fixture_message_created.message.recipient.chat_id
+        )
+
+    async def test_auto_requests_false_message_created_from_user_fetch_is_noop(
+        self, bot, fixture_message_created
+    ):
+        """from_user из payload тоже поддерживает единый fetch API."""
+        bot.auto_requests = False
+
+        result = await enrich_event(fixture_message_created, bot)
+        fetched_user = await result.from_user.fetch()
+
+        assert fetched_user is fixture_message_created.message.sender
+
+    async def test_auto_requests_false_message_answer_still_works(
+        self, bot, fixture_message_created
+    ):
+        """message.answer не должен ломаться при отключённых auto_requests."""
+        bot.auto_requests = False
+        bot.send_message = AsyncMock()
+
+        result = await enrich_event(fixture_message_created, bot)
+        await result.message.answer(text="hello")
+
+        bot.send_message.assert_awaited_once()
+
+    async def test_auto_requests_false_message_removed_fetches_lazily(
+        self,
+        bot,
+        fixture_message_removed,
+    ):
+        """MessageRemoved вручную догружает chat и затем участника."""
+        fake_chat = _make_chat(ChatType.CHAT)
+        fake_member = MagicMock()
+        bot.auto_requests = False
+        bot.get_chat_by_id = AsyncMock(return_value=fake_chat)
+        bot.get_chat_member = AsyncMock(return_value=fake_member)
+
+        result = await enrich_event(fixture_message_removed, bot)
+
+        assert isinstance(result.chat, ChatRef)
+        assert isinstance(result.from_user, FromUserRef)
+        bot.get_chat_by_id.assert_not_called()
+        bot.get_chat_member.assert_not_called()
+
+        fetched_from_user = await result.from_user.fetch()
+
+        assert fetched_from_user is fake_member
+        assert result.chat is fake_chat
+        assert result.from_user is fake_member
+        bot.get_chat_by_id.assert_awaited_once_with(
+            fixture_message_removed.chat_id
+        )
+        bot.get_chat_member.assert_awaited_once_with(
+            chat_id=fixture_message_removed.chat_id,
+            user_id=fixture_message_removed.user_id,
+        )
+
+    async def test_auto_requests_false_user_removed_from_user_fetches_lazily(
+        self, bot, fixture_user_removed
+    ):
+        """UserRemoved с admin_id догружает инициатора только вручную."""
+        fake_admin = MagicMock()
+        fixture_user_removed.admin_id = 9999
+        bot.auto_requests = False
+        bot.get_chat_member = AsyncMock(return_value=fake_admin)
+
+        result = await enrich_event(fixture_user_removed, bot)
+
+        assert result.chat is not None
+        assert isinstance(result.from_user, FromUserRef)
+        bot.get_chat_member.assert_not_called()
+
+        fetched_from_user = await result.from_user.fetch()
+
+        assert fetched_from_user is fake_admin
+        assert result.from_user is fake_admin
+        bot.get_chat_member.assert_awaited_once_with(
+            chat_id=fixture_user_removed.chat_id,
+            user_id=fixture_user_removed.admin_id,
+        )
 
     async def test_full_pipeline_message_created(
         self, bot, fixture_message_created

--- a/tests/test_fetchable_refs.py
+++ b/tests/test_fetchable_refs.py
@@ -78,7 +78,7 @@ async def test_base_update_fetch_chat_ignores_non_lazy_fetch_method():
     assert not chat.fetch_called
 
 
-async def test_base_update_fetch_chat_awaits_fetch_method(bot):
+async def test_base_update_fetch_chat_awaits_lazy_ref(bot):
     resolved = object()
     event = DummyUpdate(timestamp=1)
     event.chat = LazyRef(
@@ -121,7 +121,7 @@ async def test_base_update_fetch_from_user_ignores_non_lazy_fetch_method():
     assert not from_user.fetch_called
 
 
-async def test_base_update_fetch_from_user_awaits_fetch_method(bot):
+async def test_base_update_fetch_from_user_awaits_lazy_ref(bot):
     resolved = object()
     event = DummyUpdate(timestamp=1)
     event.from_user = LazyRef(
@@ -132,3 +132,10 @@ async def test_base_update_fetch_from_user_awaits_fetch_method(bot):
     )
 
     assert await event.fetch_from_user() is resolved
+
+
+async def test_base_update_fetch_field_unknown_field_raises_clear_error():
+    event = DummyUpdate(timestamp=1)
+
+    with pytest.raises(AttributeError, match=r"has no field 'missing'"):
+        await event._fetch_field("missing")

--- a/tests/test_fetchable_refs.py
+++ b/tests/test_fetchable_refs.py
@@ -61,6 +61,23 @@ async def test_base_update_fetch_chat_returns_existing_value():
     assert await event.fetch_chat() is chat
 
 
+async def test_base_update_fetch_chat_ignores_non_lazy_fetch_method():
+    class ChatLike:
+        def __init__(self) -> None:
+            self.fetch_called = False
+
+        async def fetch(self):
+            self.fetch_called = True
+            return "unexpected"
+
+    event = DummyUpdate(timestamp=1)
+    chat = ChatLike()
+    event.chat = chat
+
+    assert await event.fetch_chat() is chat
+    assert not chat.fetch_called
+
+
 async def test_base_update_fetch_chat_awaits_fetch_method(bot):
     resolved = object()
     event = DummyUpdate(timestamp=1)
@@ -85,6 +102,23 @@ async def test_base_update_fetch_from_user_returns_existing_value():
     event.from_user = from_user
 
     assert await event.fetch_from_user() is from_user
+
+
+async def test_base_update_fetch_from_user_ignores_non_lazy_fetch_method():
+    class UserLike:
+        def __init__(self) -> None:
+            self.fetch_called = False
+
+        async def fetch(self):
+            self.fetch_called = True
+            return "unexpected"
+
+    event = DummyUpdate(timestamp=1)
+    from_user = UserLike()
+    event.from_user = from_user
+
+    assert await event.fetch_from_user() is from_user
+    assert not from_user.fetch_called
 
 
 async def test_base_update_fetch_from_user_awaits_fetch_method(bot):

--- a/tests/test_fetchable_refs.py
+++ b/tests/test_fetchable_refs.py
@@ -1,0 +1,100 @@
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from maxapi.enums.update import UpdateType
+from maxapi.types.fetchable import LazyRef
+from maxapi.types.updates.base_update import BaseUpdate
+
+
+class DummyUpdate(BaseUpdate):
+    update_type: UpdateType = UpdateType.BOT_STARTED
+
+
+async def test_lazy_ref_pending_attr_error_and_repr(bot):
+    ref = LazyRef(
+        bot=bot,
+        fetcher=AsyncMock(),
+        setter=MagicMock(),
+        description="chat_id=1",
+    )
+
+    assert not ref
+    assert "pending" in repr(ref)
+
+    with pytest.raises(AttributeError, match=r"await ref\.fetch\(\)"):
+        _ = ref.title
+
+
+async def test_lazy_ref_fetch_caches_and_exposes_attributes(bot):
+    resolved = type("Resolved", (), {"title": "chat-title"})()
+    fetcher = AsyncMock(return_value=resolved)
+    setter = MagicMock()
+    ref = LazyRef(
+        bot=bot,
+        fetcher=fetcher,
+        setter=setter,
+        description="chat_id=123",
+    )
+
+    first = await ref.fetch()
+    second = await ref.fetch()
+
+    assert first is resolved
+    assert second is resolved
+    assert ref.title == "chat-title"
+    assert ref
+    assert "resolved" in repr(ref)
+    fetcher.assert_awaited_once()
+    setter.assert_called_once_with(resolved)
+
+
+async def test_base_update_fetch_chat_handles_none():
+    event = DummyUpdate(timestamp=1)
+    assert await event.fetch_chat() is None
+
+
+async def test_base_update_fetch_chat_returns_existing_value():
+    event = DummyUpdate(timestamp=1)
+    chat = object()
+    event.chat = chat
+
+    assert await event.fetch_chat() is chat
+
+
+async def test_base_update_fetch_chat_awaits_fetch_method(bot):
+    resolved = object()
+    event = DummyUpdate(timestamp=1)
+    event.chat = LazyRef(
+        bot=bot,
+        fetcher=AsyncMock(return_value=resolved),
+        setter=MagicMock(),
+        description="chat_id=7",
+    )
+
+    assert await event.fetch_chat() is resolved
+
+
+async def test_base_update_fetch_from_user_handles_none():
+    event = DummyUpdate(timestamp=1)
+    assert await event.fetch_from_user() is None
+
+
+async def test_base_update_fetch_from_user_returns_existing_value():
+    event = DummyUpdate(timestamp=1)
+    from_user = object()
+    event.from_user = from_user
+
+    assert await event.fetch_from_user() is from_user
+
+
+async def test_base_update_fetch_from_user_awaits_fetch_method(bot):
+    resolved = object()
+    event = DummyUpdate(timestamp=1)
+    event.from_user = LazyRef(
+        bot=bot,
+        fetcher=AsyncMock(return_value=resolved),
+        setter=MagicMock(),
+        description="user_id=9",
+    )
+
+    assert await event.fetch_from_user() is resolved

--- a/tests/test_fetchable_refs.py
+++ b/tests/test_fetchable_refs.py
@@ -1,3 +1,4 @@
+import asyncio
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -45,6 +46,40 @@ async def test_lazy_ref_fetch_caches_and_exposes_attributes(bot):
     assert ref
     assert "resolved" in repr(ref)
     fetcher.assert_awaited_once()
+    setter.assert_called_once_with(resolved)
+
+
+async def test_lazy_ref_fetch_is_concurrency_safe(bot):
+    resolved = type("Resolved", (), {"title": "chat-title"})()
+    setter = MagicMock()
+    started = asyncio.Event()
+    release = asyncio.Event()
+    calls = 0
+
+    async def fetcher():
+        nonlocal calls
+        calls += 1
+        started.set()
+        await release.wait()
+        return resolved
+
+    ref = LazyRef(
+        bot=bot,
+        fetcher=fetcher,
+        setter=setter,
+        description="chat_id=123",
+    )
+
+    first_task = asyncio.create_task(ref.fetch())
+    await started.wait()
+    second_task = asyncio.create_task(ref.fetch())
+    release.set()
+
+    first, second = await asyncio.gather(first_task, second_task)
+
+    assert first is resolved
+    assert second is resolved
+    assert calls == 1
     setter.assert_called_once_with(resolved)
 
 


### PR DESCRIPTION
Если бот создан с `auto_requests=False`, то `event.chat` и
`event.from_user` могут быть lazy ref. В этом режиме запрашиваем их
явно:

```python
chat = await event.fetch_chat()
from_user = await event.fetch_from_user()

# или через сами ref-объекты
chat = await event.chat.fetch() if event.chat else None
from_user = await event.from_user.fetch() if event.from_user else None
```