### PR TITLE
docs: исправлен пример lazy ref — is not None вместо truthiness

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -191,9 +191,12 @@ if __name__ == '__main__':
 chat = await event.fetch_chat()
 from_user = await event.fetch_from_user()
 
-# или через сами ref-объекты
-chat = await event.chat.fetch() if event.chat else None
-from_user = await event.from_user.fetch() if event.from_user else None
+# или через сами ref-объекты (проверяйте через is not None,
+# т.к. pending lazy ref является falsy)
+chat = await event.chat.fetch() if event.chat is not None else None
+from_user = (
+    await event.from_user.fetch() if event.from_user is not None else None
+)
 ```
 
 ## MagicFilter


### PR DESCRIPTION
## Описание

Исправлен нерабочий паттерн в документации для `auto_requests=False`.

### Проблема

Pending `LazyRef` является falsy (`bool(ref)` = `False`), поэтому паттерн:

```python
chat = await event.chat.fetch() if event.chat else None
```

никогда не вызовет `fetch()` — условие `if event.chat` вернёт `False` для lazy ref, и пользователь всегда получит `None`.

### Исправление

```python
chat = await event.chat.fetch() if event.chat is not None else None
```

Проверка `is not None` корректно отличает "lazy ref существует" от "ref не назначен".

Также добавлен комментарий в коде, объясняющий почему нужен `is not None`.

### Рекомендуемый подход

Основной API остаётся `await event.fetch_chat()` — он работает корректно во всех случаях.