### PR TITLE
fix: корректный тип payload для share-вложения (closes #108)

### DIFF
--- a/maxapi/types/__init__.py
+++ b/maxapi/types/__init__.py
@@ -5,6 +5,7 @@ from ..types.attachments.attachment import (
     ContactAttachmentPayload,
     OtherAttachmentPayload,
     PhotoAttachmentPayload,
+    ShareAttachmentPayload,
     StickerAttachmentPayload,
 )
 from ..types.attachments.buttons.callback_button import CallbackButton
@@ -78,6 +79,7 @@ __all__ = [
     "PhotoAttachmentRequestPayload",
     "RequestContactButton",
     "RequestGeoLocationButton",
+    "ShareAttachmentPayload",
     "StickerAttachmentPayload",
     "UpdateUnion",
     "UserAdded",

--- a/maxapi/types/attachments/attachment.py
+++ b/maxapi/types/attachments/attachment.py
@@ -53,6 +53,19 @@ class OtherAttachmentPayload(BaseModel):
     token: str | None = None
 
 
+class ShareAttachmentPayload(BaseModel):
+    """
+    Данные для вложения типа "share".
+
+    Attributes:
+        url (str): URL расшаренного ресурса.
+        token (str): Токен доступа.
+    """
+
+    url: str
+    token: str
+
+
 class ContactAttachmentPayload(BaseModel):
     """
     Данные для контакта.
@@ -105,6 +118,7 @@ class Attachment(BaseModel):
         AttachmentUpload
         | PhotoAttachmentPayload
         | OtherAttachmentPayload
+        | ShareAttachmentPayload
         | ButtonsPayload
         | ContactAttachmentPayload
         | StickerAttachmentPayload

--- a/maxapi/types/attachments/share.py
+++ b/maxapi/types/attachments/share.py
@@ -1,7 +1,7 @@
 from typing import Literal
 
 from ...enums.attachment import AttachmentType
-from .attachment import Attachment
+from .attachment import Attachment, ShareAttachmentPayload
 
 
 class Share(Attachment):
@@ -12,6 +12,8 @@ class Share(Attachment):
         title (Optional[str]): Заголовок для шаринга.
         description (Optional[str]): Описание.
         image_url (Optional[str]): URL изображения для предпросмотра.
+        payload (Optional[ShareAttachmentPayload]): Данные share-вложения
+            (url + token).
     """
 
     type: Literal[  # pyright: ignore[reportIncompatibleVariableOverride]
@@ -20,3 +22,6 @@ class Share(Attachment):
     title: str | None = None
     description: str | None = None
     image_url: str | None = None
+    payload: ShareAttachmentPayload | None = (  # pyright: ignore[reportIncompatibleVariableOverride]
+        None
+    )

--- a/tests/test_serialization_models.py
+++ b/tests/test_serialization_models.py
@@ -7,8 +7,12 @@ from maxapi.types import CallbackButton, ClipboardButton, LinkButton
 from maxapi.types.attachments.attachment import (
     Attachment,
     ButtonsPayload,
+    OtherAttachmentPayload,
     PhotoAttachmentPayload,
+    ShareAttachmentPayload,
 )
+from maxapi.types.attachments.file import File
+from maxapi.types.attachments.share import Share
 from maxapi.types.message import (
     MarkupElement,
     Message,
@@ -79,6 +83,72 @@ def test_attachment_serialize_deserialize(faker):
     assert att2.type == att.type
     assert isinstance(att2.payload, PhotoAttachmentPayload)
     assert att2.payload.photo_id == payload.photo_id
+
+
+def test_share_attachment_payload_deserialize():
+    """
+    Регрессия для #108: входящий attachment с type="share" должен
+    десериализоваться как Share с payload типа ShareAttachmentPayload,
+    чтобы пользователь мог pattern-match на ShareAttachmentPayload,
+    а не получать OtherAttachmentPayload (который "для файлов").
+    """
+    body = MessageBody.model_validate(
+        {
+            "mid": "mid.test",
+            "seq": 1,
+            "attachments": [
+                {
+                    "type": "share",
+                    "payload": {
+                        "url": "https://max.ru/c/x/AZ2I.bkQ",
+                        "token": "f9LHodD0cOL",
+                    },
+                    "title": "Title",
+                    "description": "Desc",
+                    "image_url": "https://i.oneme.ru/i?r=abc",
+                }
+            ],
+        }
+    )
+
+    att = body.attachments[0]
+    assert isinstance(att, Share)
+    assert att.title == "Title"
+    assert att.description == "Desc"
+    assert att.image_url == "https://i.oneme.ru/i?r=abc"
+    assert isinstance(att.payload, ShareAttachmentPayload)
+    assert att.payload.url == "https://max.ru/c/x/AZ2I.bkQ"
+    assert att.payload.token == "f9LHodD0cOL"
+
+
+def test_file_attachment_payload_unchanged_by_share_fix():
+    """
+    Страховка: после добавления ShareAttachmentPayload файл-вложение
+    продолжает десериализовываться как File c OtherAttachmentPayload
+    (не перехватывается ShareAttachmentPayload-классом).
+    """
+    body = MessageBody.model_validate(
+        {
+            "mid": "mid.test",
+            "seq": 1,
+            "attachments": [
+                {
+                    "type": "file",
+                    "payload": {
+                        "url": "https://fd.oneme.ru/some/file",
+                        "token": "filetok",
+                    },
+                    "filename": "doc.pdf",
+                    "size": 1024,
+                }
+            ],
+        }
+    )
+
+    att = body.attachments[0]
+    assert isinstance(att, File)
+    assert isinstance(att.payload, OtherAttachmentPayload)
+    assert att.payload.url == "https://fd.oneme.ru/some/file"
 
 
 def test_buttons_payload_deserialize_uses_button_type_discriminator():


### PR DESCRIPTION
## Что делает PR

Фикс для #108. Входящий attachment с `type="share"` теперь десериализуется с `payload` типа `ShareAttachmentPayload` вместо `OtherAttachmentPayload` (который по докстрингу «для файлов»), так что пользователь может делать pattern-matching:

```python
match att.payload:
    case ShareAttachmentPayload(): ...      # теперь работает
    case PhotoAttachmentPayload(): ...
    case OtherAttachmentPayload(): ...      # файлы/аудио/видео
```

## Root cause

- `Attachments` union (`maxapi/types/attachments/__init__.py`) — discriminated по `type`, поэтому сам attachment корректно резолвится в `Share`.
- `Share.payload` наследовался от базового `Attachment`, а в его union (`attachment.py`) не было `ShareAttachmentPayload`. `OtherAttachmentPayload` = `{url, token | None}` — суперсет для payload share-а, pydantic smart-union (2.x) выбирал его первым.

## Что меняется

1. Добавлен класс `ShareAttachmentPayload` с `url: str`, `token: str` в `maxapi/types/attachments/attachment.py`.
2. `Share` переопределяет `payload: ShareAttachmentPayload | None = None`. Это ключевая правка — она локализует фикс именно в `Share`, **не затрагивая** payload у `File` / `Audio` / `Video` (они продолжают работать через `OtherAttachmentPayload`).
3. `ShareAttachmentPayload` также добавлен в базовый `Attachment.payload`-union **после** `OtherAttachmentPayload` — чтобы явная сборка `Attachment(type=SHARE, payload=ShareAttachmentPayload(...))` была типобезопасна, без регрессии на File/Audio/Video.
4. `ShareAttachmentPayload` экспортирован из `maxapi.types`.

## Тесты

- `test_share_attachment_payload_deserialize` — регрессия #108 (share → `Share` + `ShareAttachmentPayload`).
- `test_file_attachment_payload_unchanged_by_share_fix` — страховка, что `File` по-прежнему получает `OtherAttachmentPayload`.

Локальный прогон: `tests/test_serialization_models.py` — все 7 тестов зелёные, полный прогон (кроме `test_webhook`, где нет опциональных зависимостей, и `test_dispatcher`, где нет `aresponses`) — 494 passed.

## Нотки
- Совместимо: ничего не ломается для существующих пользователей `OtherAttachmentPayload` — они у файлов/аудио/видео остаются прежними.
- Сценарий из issue воспроизведён на чистом PyPI `maxapi==0.9.18`, фикс проверен на ветке.