### PR TITLE
ix(callback_payload): unpack empty optional fields as None

### DIFF
--- a/maxapi/filters/callback_payload.py
+++ b/maxapi/filters/callback_payload.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
+from types import UnionType
 from typing import (
     TYPE_CHECKING,
     Any,
     ClassVar,
+    Union,
+    get_args,
+    get_origin,
 )
 
 from pydantic import BaseModel
@@ -104,9 +108,26 @@ class CallbackPayload(BaseModel):
                 f"получено {len(parts) - 1}"
             )
 
-        kwargs = dict(zip(field_names, parts[1:], strict=True))
+        kwargs: dict[str, Any] = {}
+        for field_name, raw_value in zip(field_names, parts[1:], strict=True):
+            if raw_value == "" and cls._is_nullable_field(field_name):
+                kwargs[field_name] = None
+            else:
+                kwargs[field_name] = raw_value
+
         # noinspection PyArgumentList
         return cls(**kwargs)
+
+    @classmethod
+    def _is_nullable_field(cls, field_name: str) -> bool:
+        field = cls.model_fields[field_name]
+        annotation = field.annotation
+        origin = get_origin(annotation)
+
+        if origin in (Union, UnionType):
+            return type(None) in get_args(annotation)
+
+        return False
 
     @classmethod
     def attrs(cls) -> list[str]:

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -231,3 +231,29 @@ class TestCallbackPayloadFilter:
         result = await payload_filter(event)
 
         assert result is False
+
+    def test_callback_payload_unpack_optional_empty_as_none(self):
+        """Пустые сегменты payload должны становиться None для Optional."""
+
+        class IqPayload(CallbackPayload, prefix="iq"):
+            action: str
+            timestamp: int | None = None
+            callback_storage_id: int | None = None
+
+        payload = IqPayload.unpack("iq|meter_readings_enter||")
+
+        assert payload.action == "meter_readings_enter"
+        assert payload.timestamp is None
+        assert payload.callback_storage_id is None
+
+    def test_callback_payload_unpack_required_string_keeps_empty(self):
+        """Для обязательного str пустое значение остаётся пустой строкой."""
+
+        class RequiredPayload(CallbackPayload, prefix="rq"):
+            action: str
+            required_text: str
+
+        payload = RequiredPayload.unpack("rq|do_something|")
+
+        assert payload.action == "do_something"
+        assert payload.required_text == ""


### PR DESCRIPTION
## Что исправлено

Сейчас `CallbackPayload.pack()` сериализует `None` как пустую строку, но `CallbackPayload.unpack()` не восстанавливает это значение обратно в `None` для `Optional` полей.

Из-за этого сериализация и десериализация работают несимметрично:
- при `pack()` значение `None` превращается в пустой сегмент
- при `unpack()` пустой сегмент остаётся строкой, хотя поле может быть `Optional`

В этом PR пустые сегменты корректно преобразуются в `None` для nullable-полей.
Для обязательных строковых полей пустая строка по-прежнему остаётся пустой строкой.

## Зачем это нужно

Такое поведение делает `CallbackPayload` более предсказуемым и избавляет от ручной постобработки после `unpack()`.

## Пример

```python
class Payload(CallbackPayload, prefix="p"):
    action: str
    timestamp: int | None = None

payload = Payload.unpack("p|run|")
```

До:
```python
assert payload.timestamp == ""
```
После:
```python
assert payload.timestamp is None
```