### PR TITLE
пропуск пустых вложений клавиатуры

### DIFF
--- a/maxapi/methods/send_message.py
+++ b/maxapi/methods/send_message.py
@@ -5,13 +5,13 @@ from typing import TYPE_CHECKING, Any, cast
 
 from ..connection.base import BaseConnection
 from ..enums.api_path import ApiPath
-from ..enums.attachment import AttachmentType
 from ..enums.http_method import HTTPMethod
 from ..enums.parse_mode import ParseMode, TextFormat
 from ..exceptions.max import MaxApiError
 from ..loggers import logger_bot
 from ..types.attachments import Attachments
-from ..types.attachments.attachment import Attachment, ButtonsPayload
+from ..types.attachments.attachment import Attachment
+from ..types.attachments.buttons.attachment_button import AttachmentButton
 from ..types.attachments.upload import AttachmentUpload
 from ..types.input_media import InputMedia, InputMediaBuffer
 from ..types.message import NewMessageLink
@@ -135,11 +135,8 @@ class SendMessage(BaseConnection):
 
         if self.attachments:
             for att in self.attachments:
-                if (
-                    isinstance(att, Attachment)
-                    and att.type == AttachmentType.INLINE_KEYBOARD
-                    and isinstance(att.payload, ButtonsPayload)
-                    and not any(att.payload.buttons)
+                if isinstance(att, AttachmentButton) and not any(
+                    att.payload.buttons
                 ):
                     continue
 

--- a/maxapi/methods/send_message.py
+++ b/maxapi/methods/send_message.py
@@ -134,6 +134,14 @@ class SendMessage(BaseConnection):
 
         if self.attachments:
             for att in self.attachments:
+                if (
+                    isinstance(att, Attachment)
+                    and str(att.type) == "inline_keyboard"
+                    and hasattr(att.payload, "buttons")
+                    and not any(att.payload.buttons)
+                ):
+                    continue
+
                 if isinstance(att, (InputMedia, InputMediaBuffer)):
                     has_input_media = True
 

--- a/maxapi/methods/send_message.py
+++ b/maxapi/methods/send_message.py
@@ -4,8 +4,8 @@ import warnings
 from typing import TYPE_CHECKING, Any, cast
 
 from ..connection.base import BaseConnection
-from ..enums.attachment import AttachmentType
 from ..enums.api_path import ApiPath
+from ..enums.attachment import AttachmentType
 from ..enums.http_method import HTTPMethod
 from ..enums.parse_mode import ParseMode, TextFormat
 from ..exceptions.max import MaxApiError

--- a/maxapi/methods/send_message.py
+++ b/maxapi/methods/send_message.py
@@ -4,13 +4,14 @@ import warnings
 from typing import TYPE_CHECKING, Any, cast
 
 from ..connection.base import BaseConnection
+from ..enums.attachment import AttachmentType
 from ..enums.api_path import ApiPath
 from ..enums.http_method import HTTPMethod
 from ..enums.parse_mode import ParseMode, TextFormat
 from ..exceptions.max import MaxApiError
 from ..loggers import logger_bot
 from ..types.attachments import Attachments
-from ..types.attachments.attachment import Attachment
+from ..types.attachments.attachment import Attachment, ButtonsPayload
 from ..types.attachments.upload import AttachmentUpload
 from ..types.input_media import InputMedia, InputMediaBuffer
 from ..types.message import NewMessageLink
@@ -136,8 +137,8 @@ class SendMessage(BaseConnection):
             for att in self.attachments:
                 if (
                     isinstance(att, Attachment)
-                    and str(att.type) == "inline_keyboard"
-                    and hasattr(att.payload, "buttons")
+                    and att.type == AttachmentType.INLINE_KEYBOARD
+                    and isinstance(att.payload, ButtonsPayload)
                     and not any(att.payload.buttons)
                 ):
                     continue

--- a/maxapi/types/attachments/buttons/attachment_button.py
+++ b/maxapi/types/attachments/buttons/attachment_button.py
@@ -1,7 +1,7 @@
 from typing import Literal
 
 from ....enums.attachment import AttachmentType
-from ..attachment import Attachment
+from ..attachment import Attachment, ButtonsPayload
 
 
 class AttachmentButton(Attachment):
@@ -14,3 +14,4 @@ class AttachmentButton(Attachment):
     """
 
     type: Literal[AttachmentType.INLINE_KEYBOARD]
+    payload: ButtonsPayload

--- a/maxapi/utils/inline_keyboard.py
+++ b/maxapi/utils/inline_keyboard.py
@@ -96,4 +96,4 @@ class InlineKeyboardBuilder:
         return AttachmentButton(
             type=AttachmentType.INLINE_KEYBOARD,
             payload=ButtonsPayload(buttons=self.payload),
-        )
+        )  # type: ignore[call-arg]

--- a/tests/test_send_message_fetch.py
+++ b/tests/test_send_message_fetch.py
@@ -1,13 +1,11 @@
 from unittest.mock import AsyncMock, Mock, patch
 
-import pytest
 from maxapi.connection.base import BaseConnection
 from maxapi.methods.send_message import SendMessage
 from maxapi.types.attachments.buttons.callback_button import CallbackButton
 from maxapi.utils.inline_keyboard import InlineKeyboardBuilder
 
 
-@pytest.mark.asyncio
 async def test_send_message_fetch_skips_empty_inline_keyboard(bot):
     method = SendMessage(
         bot=bot,

--- a/tests/test_send_message_fetch.py
+++ b/tests/test_send_message_fetch.py
@@ -1,0 +1,31 @@
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+from maxapi.connection.base import BaseConnection
+from maxapi.methods.send_message import SendMessage
+from maxapi.types.attachments.buttons.callback_button import CallbackButton
+from maxapi.utils.inline_keyboard import InlineKeyboardBuilder
+
+
+@pytest.mark.asyncio
+async def test_send_message_fetch_skips_empty_inline_keyboard(bot):
+    method = SendMessage(
+        bot=bot,
+        chat_id=1,
+        attachments=[
+            InlineKeyboardBuilder().as_markup(),
+            InlineKeyboardBuilder()
+            .row(CallbackButton(text="ok", payload="payload"))
+            .as_markup(),
+        ],
+    )
+
+    with patch.object(
+        BaseConnection, "request", new=AsyncMock(return_value=Mock())
+    ) as mocked_request:
+        await method.fetch()
+
+    attachments = mocked_request.call_args.kwargs["json"]["attachments"]
+    assert len(attachments) == 1
+    assert attachments[0]["type"] == "inline_keyboard"
+    assert attachments[0]["payload"]["buttons"][0][0]["text"] == "ok"


### PR DESCRIPTION
## Что исправлено

Сейчас при отправке сообщения в attachments может попасть пустая inline-клавиатура.

Например, `InlineKeyboardBuilder` по умолчанию создаёт структуру `[[]]`, и если такая клавиатура передаётся в сообщение без кнопок, она всё равно сериализуется как attachment типа `inline_keyboard`.

В этом PR такие пустые inline keyboard attachments пропускаются и не отправляются в API.

## Зачем это нужно

Пустая клавиатура не несёт полезной нагрузки и может приводить к лишним ошибкам или некорректному поведению при отправке сообщения.

## Что считается пустой клавиатурой

Attachment типа `inline_keyboard`, у которого нет ни одного ряда с кнопками.