### PR TITLE
Исправление: утечка соединения при ошибке в upload_file / upload_file_buffer

### DIFF
--- a/maxapi/connection/base.py
+++ b/maxapi/connection/base.py
@@ -240,8 +240,8 @@ class BaseConnection(BotMixin):
             async with ClientSession(
                 timeout=bot.default_connection.timeout
             ) as temp_session:
-                response = await temp_session.post(url=url, data=form)
-                return await response.text()
+                async with temp_session.post(url=url, data=form) as response:
+                    return await response.text()
 
     async def upload_file_buffer(
         self, filename: str, url: str, buffer: bytes, type: UploadType
@@ -291,8 +291,8 @@ class BaseConnection(BotMixin):
             async with ClientSession(
                 timeout=bot.default_connection.timeout
             ) as temp_session:
-                response = await temp_session.post(url=url, data=form)
-                return await response.text()
+                async with temp_session.post(url=url, data=form) as response:
+                    return await response.text()
 
     async def download_file(
         self,

--- a/maxapi/connection/base.py
+++ b/maxapi/connection/base.py
@@ -237,11 +237,13 @@ class BaseConnection(BotMixin):
             async with session.post(url=url, data=form) as response:
                 return await response.text()
         else:
-            async with ClientSession(
-                timeout=bot.default_connection.timeout
-            ) as temp_session:
-                async with temp_session.post(url=url, data=form) as response:
-                    return await response.text()
+            async with (
+                ClientSession(
+                    timeout=bot.default_connection.timeout
+                ) as temp_session,
+                temp_session.post(url=url, data=form) as response,
+            ):
+                return await response.text()
 
     async def upload_file_buffer(
         self, filename: str, url: str, buffer: bytes, type: UploadType
@@ -288,11 +290,13 @@ class BaseConnection(BotMixin):
             async with session.post(url=url, data=form) as response:
                 return await response.text()
         else:
-            async with ClientSession(
-                timeout=bot.default_connection.timeout
-            ) as temp_session:
-                async with temp_session.post(url=url, data=form) as response:
-                    return await response.text()
+            async with (
+                ClientSession(
+                    timeout=bot.default_connection.timeout
+                ) as temp_session,
+                temp_session.post(url=url, data=form) as response,
+            ):
+                return await response.text()
 
     async def download_file(
         self,

--- a/maxapi/connection/base.py
+++ b/maxapi/connection/base.py
@@ -234,8 +234,8 @@ class BaseConnection(BotMixin):
 
         session = bot.session
         if session is not None and not session.closed:
-            response = await session.post(url=url, data=form)
-            return await response.text()
+            async with session.post(url=url, data=form) as response:
+                return await response.text()
         else:
             async with ClientSession(
                 timeout=bot.default_connection.timeout
@@ -285,8 +285,8 @@ class BaseConnection(BotMixin):
 
         session = bot.session
         if session is not None and not session.closed:
-            response = await session.post(url=url, data=form)
-            return await response.text()
+            async with session.post(url=url, data=form) as response:
+                return await response.text()
         else:
             async with ClientSession(
                 timeout=bot.default_connection.timeout

--- a/tests/test_coverage_gaps.py
+++ b/tests/test_coverage_gaps.py
@@ -504,6 +504,7 @@ class TestBaseConnectionUploadFallback:
 
         mock_cm = AsyncMock()
         mock_cm.__aenter__.return_value = mock_response
+        mock_cm.__aexit__.return_value = False
 
         mock_session_instance = AsyncMock()
         mock_session_instance.post = Mock(return_value=mock_cm)

--- a/tests/test_coverage_gaps.py
+++ b/tests/test_coverage_gaps.py
@@ -502,8 +502,11 @@ class TestBaseConnectionUploadFallback:
         mock_response = AsyncMock()
         mock_response.text = AsyncMock(return_value='{"token":"abc"}')
 
+        mock_cm = AsyncMock()
+        mock_cm.__aenter__.return_value = mock_response
+
         mock_session_instance = AsyncMock()
-        mock_session_instance.post = AsyncMock(return_value=mock_response)
+        mock_session_instance.post = Mock(return_value=mock_cm)
         mock_session_instance.__aenter__ = AsyncMock(
             return_value=mock_session_instance
         )
@@ -538,9 +541,12 @@ class TestBaseConnectionUploadFallback:
 
         mock_response = AsyncMock()
         mock_response.text = AsyncMock(return_value='{"token":"xyz"}')
+        mock_cm_buf = AsyncMock()
+        mock_cm_buf.__aenter__.return_value = mock_response
+
         bot.session = MagicMock()
         bot.session.closed = False
-        bot.session.post = AsyncMock(return_value=mock_response)
+        bot.session.post = Mock(return_value=mock_cm_buf)
 
         # Подменяем puremagic, чтобы вернуть распознаваемый MIME-матч,
         # и mimetypes.guess_extension — чтобы вернуть реальное расширение.

--- a/tests/test_coverage_gaps.py
+++ b/tests/test_coverage_gaps.py
@@ -543,6 +543,7 @@ class TestBaseConnectionUploadFallback:
         mock_response.text = AsyncMock(return_value='{"token":"xyz"}')
         mock_cm_buf = AsyncMock()
         mock_cm_buf.__aenter__.return_value = mock_response
+        mock_cm_buf.__aexit__.return_value = False
 
         bot.session = MagicMock()
         bot.session.closed = False
@@ -576,3 +577,46 @@ class TestBaseConnectionUploadFallback:
         # guess_extension was called (the covered line)
         mock_ge.assert_called_once_with("image/png")
         assert result == '{"token":"xyz"}'
+
+    async def test_upload_file_buffer_uses_temp_session_when_session_is_none(
+        self, bot
+    ):
+        """upload_file_buffer falls back to a new ClientSession
+        when bot.session=None."""
+        from maxapi.connection.base import BaseConnection
+        from maxapi.enums.upload_type import UploadType
+
+        conn = BaseConnection()
+        conn.bot = bot
+        bot.session = None  # force the else-branch
+
+        some_buffer = b"\x00" * 32
+
+        mock_response = AsyncMock()
+        mock_response.text = AsyncMock(return_value='{"token":"buf"}')
+
+        mock_cm = AsyncMock()
+        mock_cm.__aenter__.return_value = mock_response
+        mock_cm.__aexit__.return_value = False
+
+        mock_session_instance = AsyncMock()
+        mock_session_instance.post = Mock(return_value=mock_cm)
+        mock_session_instance.__aenter__ = AsyncMock(
+            return_value=mock_session_instance
+        )
+        mock_session_instance.__aexit__ = AsyncMock(return_value=False)
+
+        with patch(
+            "maxapi.connection.base.ClientSession",
+            return_value=mock_session_instance,
+        ):
+            result = await conn.upload_file_buffer(
+                filename="clip",
+                url="https://upload.example.com",
+                buffer=some_buffer,
+                type=UploadType.VIDEO,
+            )
+
+        assert result == '{"token":"buf"}'
+        mock_session_instance.post.assert_called_once()
+        mock_cm.__aenter__.assert_called_once()

--- a/tests/test_upload_file.py
+++ b/tests/test_upload_file.py
@@ -31,9 +31,12 @@ class TestUploadFileMimetypesFallback:
         mock_response = AsyncMock()
         mock_response.text = AsyncMock(return_value='{"token":"t"}')
 
+        mock_cm = AsyncMock()
+        mock_cm.__aenter__.return_value = mock_response
+
         mock_session = AsyncMock(spec=ClientSession)
         mock_session.closed = False
-        mock_session.post = AsyncMock(return_value=mock_response)
+        mock_session.post = Mock(return_value=mock_cm)
 
         conn, _bot = _make_connection_with_bot(session=mock_session)
 
@@ -43,7 +46,7 @@ class TestUploadFileMimetypesFallback:
             type=UploadType.IMAGE,
         )
 
-        mock_session.post.assert_awaited_once()
+        mock_session.post.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_unknown_extension_falls_back_to_type_wildcard(
@@ -56,9 +59,12 @@ class TestUploadFileMimetypesFallback:
         mock_response = AsyncMock()
         mock_response.text = AsyncMock(return_value='{"token":"t"}')
 
+        mock_cm = AsyncMock()
+        mock_cm.__aenter__.return_value = mock_response
+
         mock_session = AsyncMock(spec=ClientSession)
         mock_session.closed = False
-        mock_session.post = AsyncMock(return_value=mock_response)
+        mock_session.post = Mock(return_value=mock_cm)
 
         conn, _bot = _make_connection_with_bot(session=mock_session)
 
@@ -72,7 +78,7 @@ class TestUploadFileMimetypesFallback:
                 type=UploadType.FILE,
             )
 
-        mock_session.post.assert_awaited_once()
+        mock_session.post.assert_called_once()
 
 
 class TestUploadFileTempSession:
@@ -90,8 +96,11 @@ class TestUploadFileTempSession:
         conn, bot = _make_connection_with_bot(session=None)
         expected_timeout = bot.default_connection.timeout
 
+        mock_cm = AsyncMock()
+        mock_cm.__aenter__.return_value = mock_response
+
         mock_temp_session = AsyncMock()
-        mock_temp_session.post = AsyncMock(return_value=mock_response)
+        mock_temp_session.post = Mock(return_value=mock_cm)
 
         with patch(
             "maxapi.connection.base.ClientSession",
@@ -107,7 +116,7 @@ class TestUploadFileTempSession:
             )
 
             mock_cs_cls.assert_called_once_with(timeout=expected_timeout)
-            mock_temp_session.post.assert_awaited_once()
+            mock_temp_session.post.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_temp_session_with_timeout_when_session_closed(
@@ -126,8 +135,11 @@ class TestUploadFileTempSession:
         conn, bot = _make_connection_with_bot(session=closed_session)
         expected_timeout = bot.default_connection.timeout
 
+        mock_cm = AsyncMock()
+        mock_cm.__aenter__.return_value = mock_response
+
         mock_temp_session = AsyncMock()
-        mock_temp_session.post = AsyncMock(return_value=mock_response)
+        mock_temp_session.post = Mock(return_value=mock_cm)
 
         with patch(
             "maxapi.connection.base.ClientSession",
@@ -153,9 +165,12 @@ class TestUploadFileTempSession:
         mock_response = AsyncMock()
         mock_response.text = AsyncMock(return_value='{"token":"t"}')
 
+        mock_cm = AsyncMock()
+        mock_cm.__aenter__.return_value = mock_response
+
         mock_session = AsyncMock(spec=ClientSession)
         mock_session.closed = False
-        mock_session.post = AsyncMock(return_value=mock_response)
+        mock_session.post = Mock(return_value=mock_cm)
 
         conn, _bot = _make_connection_with_bot(session=mock_session)
 
@@ -169,4 +184,4 @@ class TestUploadFileTempSession:
             )
 
             mock_cs_cls.assert_not_called()
-            mock_session.post.assert_awaited_once()
+            mock_session.post.assert_called_once()

--- a/tests/test_upload_file.py
+++ b/tests/test_upload_file.py
@@ -33,6 +33,7 @@ class TestUploadFileMimetypesFallback:
 
         mock_cm = AsyncMock()
         mock_cm.__aenter__.return_value = mock_response
+        mock_cm.__aexit__.return_value = False
 
         mock_session = AsyncMock(spec=ClientSession)
         mock_session.closed = False
@@ -61,6 +62,7 @@ class TestUploadFileMimetypesFallback:
 
         mock_cm = AsyncMock()
         mock_cm.__aenter__.return_value = mock_response
+        mock_cm.__aexit__.return_value = False
 
         mock_session = AsyncMock(spec=ClientSession)
         mock_session.closed = False
@@ -98,6 +100,7 @@ class TestUploadFileTempSession:
 
         mock_cm = AsyncMock()
         mock_cm.__aenter__.return_value = mock_response
+        mock_cm.__aexit__.return_value = False
 
         mock_temp_session = AsyncMock()
         mock_temp_session.post = Mock(return_value=mock_cm)
@@ -137,6 +140,7 @@ class TestUploadFileTempSession:
 
         mock_cm = AsyncMock()
         mock_cm.__aenter__.return_value = mock_response
+        mock_cm.__aexit__.return_value = False
 
         mock_temp_session = AsyncMock()
         mock_temp_session.post = Mock(return_value=mock_cm)
@@ -167,6 +171,7 @@ class TestUploadFileTempSession:
 
         mock_cm = AsyncMock()
         mock_cm.__aenter__.return_value = mock_response
+        mock_cm.__aexit__.return_value = False
 
         mock_session = AsyncMock(spec=ClientSession)
         mock_session.closed = False


### PR DESCRIPTION
```
response = await session.post(url=url, data=form)
return await response.text()  # Если здесь получим исключение, то
                              # соединение не возвратится в пул ClientSession
```

В aiohttp `session.post()` возвращает response после получения заголовков, тело ещё не прочитано. `response.text()` читает тело уже отдельным вызовом. На этом этапе можем получить:
1. aiohttp.ClientPayloadError - сервер закрыл соединение до конца передачи тела
2. asyncio.TimeoutError - истёк read-таймаут пока читается тело
3. UnicodeDecodeError - сервер вернул тело с кодировкой, которую не удалось декодировать                                                                                               
                                                                                                                                                                                         
То есть сценарий реальный, но достаточно редкий — нужен сбой именно после получения заголовков, но во время чтения тела. Для upload-эндпоинтов, которые отвечают коротким JSON, вероятность невысокая, но исправление правильное — это best practice для aiohttp