### PR TITLE
fix: улучшение строгой типизации для объединенных типов (Union/Annotated)

### DIFF
--- a/maxapi/utils/inline_keyboard.py
+++ b/maxapi/utils/inline_keyboard.py
@@ -90,7 +90,7 @@ class InlineKeyboardBuilder:
         Собрать клавиатуру в объект для отправки.
 
         Returns:
-            Attachment: Объект вложения с типом INLINE_KEYBOARD.
+            AttachmentButton: Объект вложения с типом INLINE_KEYBOARD.
         """
 
         return AttachmentButton(

--- a/maxapi/utils/inline_keyboard.py
+++ b/maxapi/utils/inline_keyboard.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from ..enums.attachment import AttachmentType
-from ..types.attachments.attachment import Attachment, ButtonsPayload
+from ..types.attachments.attachment import ButtonsPayload
+from ..types.attachments.buttons.attachment_button import AttachmentButton
 
 if TYPE_CHECKING:
     from ..types.attachments.buttons import InlineButtonUnion
@@ -84,7 +85,7 @@ class InlineKeyboardBuilder:
         self.payload = new_payload
         return self
 
-    def as_markup(self) -> Attachment:
+    def as_markup(self) -> AttachmentButton:
         """
         Собрать клавиатуру в объект для отправки.
 
@@ -92,7 +93,7 @@ class InlineKeyboardBuilder:
             Attachment: Объект вложения с типом INLINE_KEYBOARD.
         """
 
-        return Attachment(
+        return AttachmentButton(
             type=AttachmentType.INLINE_KEYBOARD,
             payload=ButtonsPayload(buttons=self.payload),
-        )  # type: ignore
+        )


### PR DESCRIPTION
# Описание
Данный PR устраняет ошибки статического анализа (Pylance/Pyright), возникающие при работе со сложными объединенными типами (Union) и дискриминированными полями (Annotated).
```
max_message.body.attachments: list[Attachments]

Attachments = Annotated[
    Audio
    | Video
    | File
    | Image
    | Sticker
    | Share
    | Location
    | AttachmentButton
    | Contact,
    Field(discriminator="type"),
]
kb = InlineKeyboardBuilder()
...

max_message.body.attachments.append(kb.as_markup()) # Здесь ошибка типов,
# потому что Attachments не включает в себя Attachment. Attachment - базовый тип. 
```
Решение:
```
    def as_markup(self) -> AttachmentButton:
        """
        Собрать клавиатуру в объект для отправки.

        Returns:
            AttachmentButton: Объект вложения с типом INLINE_KEYBOARD.
        """

        return AttachmentButton(
            type=AttachmentType.INLINE_KEYBOARD,
            payload=ButtonsPayload(buttons=self.payload),
        )
```

