### PR TITLE
fix: явное логирование исключений из обработчиков

### DIFF
--- a/docs/guides/middleware.md
+++ b/docs/guides/middleware.md
@@ -212,6 +212,68 @@ async def handler(event: MessageCreated, custom_data: str):
     await event.message.answer(custom_data)
 ```
 
+## Перехват ошибок из обработчиков
+
+Если внутри хендлера возникает исключение, диспетчер оборачивает его в
+`HandlerException` и логирует. Middleware может перехватить это исключение
+до логирования — поведение зависит от типа middleware.
+
+### Outer middleware — получает `HandlerException`
+
+```python
+from maxapi.exceptions.dispatcher import HandlerException
+from maxapi.filters.middleware import BaseMiddleware
+
+
+class ErrorHandlerMiddleware(BaseMiddleware):
+    async def __call__(self, handler, event, data):
+        try:
+            await handler(event, data)
+        except HandlerException as e:
+            # e.cause — оригинальное исключение из хендлера
+            # e.handler_title — имя функции-обработчика
+            print(f"Ошибка в {e.handler_title}: {e.cause}")
+            raise  # обязательно re-raise, иначе см. примечание ниже
+
+
+dp.register_outer_middleware(ErrorHandlerMiddleware())
+```
+
+### Inner middleware — получает оригинальное исключение
+
+Inner middleware вызывается внутри хендлера, до оборачивания исключения,
+поэтому получает исходный тип исключения:
+
+```python
+class RawErrorMiddleware(BaseMiddleware):
+    async def __call__(self, handler, event, data):
+        try:
+            await handler(event, data)
+        except ValueError as e:
+            # ValueError напрямую, без HandlerException
+            print(f"Ошибка валидации: {e}")
+            raise
+
+
+@dp.message_created(Command("start"), RawErrorMiddleware())
+async def start(event: MessageCreated):
+    await event.message.answer("a" * 5000)  # поднимет ValueError
+```
+
+### Поведение по типам
+
+| Тип middleware | Получает | Доступ к оригиналу |
+|---|---|---|
+| **Inner** (в декораторе хендлера) | RAW исключение | напрямую |
+| **Router outer** | `HandlerException` | `e.cause` |
+| **Global outer** | `HandlerException` | `e.cause` |
+
+!!! warning "Не забывайте `raise` после обработки"
+    Если outer middleware поглощает `HandlerException` без `raise`,
+    диспетчер корректно определит событие как обработанное и не напишет
+    лишнего в лог. Однако `handle()` не будет логировать ошибку — вся
+    ответственность за уведомление об ошибке ложится на middleware.
+
 ## Примеры использования
 
 - Логирование

--- a/maxapi/dispatcher.py
+++ b/maxapi/dispatcher.py
@@ -1047,16 +1047,24 @@ class Dispatcher(BotMixin):
             router_id: Идентификатор роутера для логов.
             process_info: Информация о процессе для логов.
         """
-        if await self._run_router_handlers(
-            event=event,
-            data=handler_data,
-            matching_handlers=matching_handlers,
-            memory_context=memory_context,
-            current_state=current_state,
-            router_id=router_id,
-            process_info=process_info,
-        ):
+        try:
+            if await self._run_router_handlers(
+                event=event,
+                data=handler_data,
+                matching_handlers=matching_handlers,
+                memory_context=memory_context,
+                current_state=current_state,
+                router_id=router_id,
+                process_info=process_info,
+            ):
+                handler_data["_handled"] = True
+        except HandlerException:
+            # Хендлер был найден и запущен — фиксируем флаг до re-raise,
+            # чтобы router outer middleware, поглотившая исключение,
+            # не получила ложное «Проигнорировано» в handle().
+            # Симметрично тому, что делает _process_event для global outer mw.
             handler_data["_handled"] = True
+            raise
 
     async def _dispatch_to_router(
         self,

--- a/maxapi/dispatcher.py
+++ b/maxapi/dispatcher.py
@@ -1211,13 +1211,22 @@ class Dispatcher(BotMixin):
         data["context"] = memory_context
         data["raw_state"] = data["_current_state"]
 
-        router_id, is_handled = await self._iter_and_dispatch_routers(
-            event_object=event_object,
-            data=data,
-            memory_context=memory_context,
-            current_state=data["_current_state"],
-            process_info=data["_process_info"],
-        )
+        try:
+            router_id, is_handled = await self._iter_and_dispatch_routers(
+                event_object=event_object,
+                data=data,
+                memory_context=memory_context,
+                current_state=data["_current_state"],
+                process_info=data["_process_info"],
+            )
+        except HandlerException as e:
+            # Хендлер был найден и запущен — фиксируем флаги до re-raise,
+            # чтобы outer middleware, поглотившая исключение, не получила
+            # ложное "Проигнорировано" в handle().
+            data["_router_id"] = e.router_id
+            data["_is_handled"] = True
+            raise
+
         data["_router_id"] = router_id
         data["_is_handled"] = is_handled
 
@@ -1259,6 +1268,8 @@ class Dispatcher(BotMixin):
 
             try:
                 await global_chain(event_object, kwargs)
+            except HandlerException:
+                raise
             except Exception as e:
                 mem_data = await memory_context.get_data()
 
@@ -1283,6 +1294,12 @@ class Dispatcher(BotMixin):
                     process_info,
                 )
 
+        except HandlerException as e:
+            logger_dp.exception(
+                "Ошибка в обработчике: %s",
+                e,
+                exc_info=e.cause,
+            )
         except Exception as e:
             logger_dp.exception(
                 "Ошибка при обработке события: router_id: %s | %s | %r",

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -837,6 +837,42 @@ class TestHandlePipeline:
         _setup_for_handle(dispatcher, bot)
         await dispatcher.handle(fixture_message_created)  # не должно всплывать
 
+    async def test_handle_logs_handler_exception_with_str_and_cause(
+        self, dispatcher, bot, fixture_message_created, monkeypatch
+    ):
+        """
+        handle() логирует HandlerException через __str__ и передаёт
+        оригинальное исключение как exc_info.
+        """
+        import maxapi.dispatcher as dp_module
+        from maxapi.exceptions.dispatcher import HandlerException
+
+        original_cause = RuntimeError("оригинальная ошибка")
+
+        @dispatcher.message_created()
+        async def _handler(event: MessageCreated):
+            raise original_cause
+
+        _setup_for_handle(dispatcher, bot)
+
+        logged_calls: list[tuple] = []
+
+        def fake_exception(msg, *args, **kwargs):
+            logged_calls.append((msg, args, kwargs))
+
+        monkeypatch.setattr(dp_module.logger_dp, "exception", fake_exception)
+
+        await dispatcher.handle(fixture_message_created)
+
+        assert len(logged_calls) == 1
+        msg, args, kwargs = logged_calls[0]
+        assert msg == "Ошибка в обработчике: %s"
+        # args[0] — экземпляр HandlerException, логируется через __str__
+        assert isinstance(args[0], HandlerException)
+        assert args[0].cause is original_cause
+        # exc_info передаётся как оригинальное исключение, не HandlerException
+        assert kwargs.get("exc_info") is original_cause
+
     async def test_handle_catches_middleware_exception(
         self, dispatcher, bot, fixture_message_created
     ):
@@ -853,6 +889,112 @@ class TestHandlePipeline:
         dispatcher.register_outer_middleware(FailingMiddleware())
         _setup_for_handle(dispatcher, bot)
         await dispatcher.handle(fixture_message_created)  # не должно всплывать
+
+    async def test_outer_middleware_receives_handler_exception(
+        self, dispatcher, bot, fixture_message_created
+    ):
+        """
+        Outer middleware получает HandlerException при ошибке хендлера.
+
+        Оригинальное исключение доступно через HandlerException.cause.
+        """
+        from maxapi.exceptions.dispatcher import HandlerException
+        from maxapi.filters.middleware import BaseMiddleware
+
+        original_cause = RuntimeError("ошибка в хендлере")
+        caught: list[BaseException] = []
+
+        class CatchingOuterMiddleware(BaseMiddleware):
+            async def __call__(self, handler, event, data):
+                try:
+                    await handler(event, data)
+                except HandlerException as e:
+                    caught.append(e)
+                    raise
+
+        @dispatcher.message_created()
+        async def _handler(event: MessageCreated):
+            raise original_cause
+
+        dispatcher.register_outer_middleware(CatchingOuterMiddleware())
+        _setup_for_handle(dispatcher, bot)
+        await dispatcher.handle(fixture_message_created)
+
+        assert len(caught) == 1
+        assert isinstance(caught[0], HandlerException)
+        assert caught[0].cause is original_cause
+
+    async def test_outer_middleware_swallows_handler_exception_no_ignored_log(
+        self, dispatcher, bot, fixture_message_created, monkeypatch
+    ):
+        """
+        Если outer middleware поглощает HandlerException, handle() не должен
+        логировать "Проигнорировано" — хендлер ведь был найден и запущен.
+        """
+        import contextlib
+
+        import maxapi.dispatcher as dp_module
+        from maxapi.exceptions.dispatcher import HandlerException
+        from maxapi.filters.middleware import BaseMiddleware
+
+        ignored_logs: list[str] = []
+        original_info = dp_module.logger_dp.info
+
+        def fake_info(msg, *args, **kwargs):
+            if "Проигнорировано" in msg:
+                ignored_logs.append(msg)
+            else:
+                original_info(msg, *args, **kwargs)
+
+        monkeypatch.setattr(dp_module.logger_dp, "info", fake_info)
+
+        class SwallowingMiddleware(BaseMiddleware):
+            async def __call__(self, handler, event, data):
+                with contextlib.suppress(HandlerException):
+                    await handler(event, data)
+
+        @dispatcher.message_created()
+        async def _handler(event: MessageCreated):
+            raise RuntimeError("ошибка")
+
+        dispatcher.register_outer_middleware(SwallowingMiddleware())
+        _setup_for_handle(dispatcher, bot)
+        await dispatcher.handle(fixture_message_created)
+
+        assert ignored_logs == [], (
+            "handle() не должен логировать 'Проигнорировано' "
+            "когда middleware поглотила HandlerException"
+        )
+
+    async def test_inner_middleware_receives_raw_exception(
+        self, dispatcher, bot, fixture_message_created
+    ):
+        """
+        Inner middleware получает оригинальное исключение из хендлера,
+        до того как оно оборачивается в HandlerException.
+        """
+        from maxapi.filters.middleware import BaseMiddleware
+
+        original_cause = RuntimeError("ошибка в хендлере")
+        caught: list[BaseException] = []
+
+        class CatchingInnerMiddleware(BaseMiddleware):
+            async def __call__(self, handler, event, data):
+                try:
+                    await handler(event, data)
+                except RuntimeError as e:
+                    caught.append(e)
+                    raise
+
+        @dispatcher.message_created(CatchingInnerMiddleware())
+        async def _handler(event: MessageCreated):
+            raise original_cause
+
+        _setup_for_handle(dispatcher, bot)
+        await dispatcher.handle(fixture_message_created)
+
+        assert len(caught) == 1
+        assert caught[0] is original_cause
 
 
 # ===========================================================================

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -7,11 +7,14 @@
 - inner_mw срабатывает только когда handler реально совпал
 - deprecated aliases: .middlewares, .middleware(), .outer_middleware()
 - наследование outer_mw и inner_mw через дерево роутеров
+- HandlerException, поглощённая router outer mw, не приводит к ложному
+  «Проигнорировано»
 """
 
 import warnings
 
 from maxapi.dispatcher import Dispatcher, Router
+from maxapi.exceptions.dispatcher import HandlerException
 from maxapi.filters.filter import BaseFilter
 from maxapi.filters.middleware import BaseMiddleware
 from maxapi.types.updates.bot_started import BotStarted
@@ -475,3 +478,110 @@ class TestInnerMiddlewareInheritance:
 
         assert handled
         assert "global_inner:before" in log
+
+
+# ===========================================================================
+# HandlerException: поглощение router outer mw
+# ===========================================================================
+
+
+class SwallowingMW(BaseMiddleware):
+    """Middleware, перехватывающая HandlerException и не пробрасывающая её."""
+
+    def __init__(self, log: list) -> None:
+        self.log = log
+
+    async def __call__(self, handler, event, data) -> None:
+        try:
+            await handler(event, data)
+        except HandlerException:
+            self.log.append("swallowed")
+
+
+class TestRouterOuterMwSwallowedHandlerException:
+    """router outer mw, поглотившая HandlerException, не должна вызывать
+    ложное «Проигнорировано» — событие считается обработанным."""
+
+    async def test_router_outer_mw_swallows_handler_exception_is_handled(
+        self, bot, fixture_message_created
+    ):
+        """
+        Когда router outer mw глотает HandlerException:
+        - событие должно считаться обработанным (_handled = True)
+        - handle() не должен логировать «Проигнорировано»
+        """
+        dp = Dispatcher()
+        router = Router("failing_router")
+
+        swallow_log: list[str] = []
+        router.register_outer_middleware(SwallowingMW(swallow_log))
+
+        called = []
+
+        @router.message_created()
+        async def _h(event: MessageCreated):
+            called.append(event)
+            raise RuntimeError("handler failed")
+
+        dp.include_routers(router)
+        _setup(dp, bot)
+
+        # handle() не должен пробросить исключение (оно поглощается mw)
+        await dp.handle(fixture_message_created)
+
+        # handler точно вызвался
+        assert called, "handler должен был вызваться"
+        # mw проглотила HandlerException
+        assert "swallowed" in swallow_log
+
+    async def test_global_outer_mw_swallows_handler_exception_is_handled(
+        self, bot, fixture_message_created
+    ):
+        """
+        Когда global outer mw глотает HandlerException:
+        - симметричный тест для dp-уровня (уже работало, регрессия)
+        """
+        dp = Dispatcher()
+        swallow_log: list[str] = []
+        dp.register_outer_middleware(SwallowingMW(swallow_log))
+
+        called = []
+
+        @dp.message_created()
+        async def _h(event: MessageCreated):
+            called.append(event)
+            raise RuntimeError("handler failed")
+
+        _setup(dp, bot)
+        await dp.handle(fixture_message_created)
+
+        assert called
+        assert "swallowed" in swallow_log
+
+    async def test_router_outer_mw_reraises_handler_exception_still_logged(
+        self, bot, fixture_message_created, caplog
+    ):
+        """Если router outer mw НЕ глотает HandlerException — она долетает
+        до handle() и логируется как 'Ошибка в обработчике'."""
+        import logging
+
+        dp = Dispatcher()
+        router = Router("reraise_router")
+
+        class ReRaiseMW(BaseMiddleware):
+            async def __call__(self, handler, event, data) -> None:
+                await handler(event, data)  # не ловит — пробрасывает
+
+        router.register_outer_middleware(ReRaiseMW())
+
+        @router.message_created()
+        async def _h(event: MessageCreated):
+            raise RuntimeError("boom")
+
+        dp.include_routers(router)
+        _setup(dp, bot)
+
+        with caplog.at_level(logging.ERROR, logger="maxapi.dispatcher"):
+            await dp.handle(fixture_message_created)
+
+        assert any("Ошибка в обработчике" in r.message for r in caplog.records)


### PR DESCRIPTION
## Проблема

При возникновении ошибки внутри обработчика (например, `ValueError` при превышении лимита символов
в `send_message`) исключение не было видно пользователю: диспетчер оборачивал `HandlerException` в
`MiddlewareException`, затем глотал всю цепочку через `logger_dp.exception()`. В итоге в логе
появлялось малоинформативное сообщение с `router_id: None`, а оригинальное исключение было
погребено на два уровня вложенности.

**Как воспроизвести:**

```python
@dp.message_created()
async def handler(event):
    await event.message.answer("a" * 5000)  # ValueError в __init__
    # дальше не выполнялось, ошибка незаметна
```

## Решение

### 1. Разделение ошибок хендлера и middleware в `Dispatcher.handle()`

- Добавлен `except HandlerException: raise` во внутренний `try`-блок — `HandlerException` больше не
  оборачивается в `MiddlewareException`.
- Добавлен отдельный `except HandlerException as e` во внешнем блоке: логирует через `__str__`
  исключения (содержит `handler`, `router_id`, `process`, `context_keys`, `cause`) и передаёт
  `exc_info=e.cause` — в трейсбеке виден реальный источник ошибки в коде пользователя.

**До:**

```
ERROR:dispatcher:Ошибка при обработке события: router_id: None | ... | MiddlewareException(middleware=..., cause=HandlerException: ...)
Traceback: ... dispatcher.py:_execute_handler ...
```

**После:**

```
ERROR:dispatcher:Ошибка в обработчике: HandlerException(handler=my_handler, router_id=..., process=MESSAGE_CREATED | chat_id: X, user_id: Y, context_keys=[], cause=ValueError: text должен быть меньше 4000 символов)
Traceback (most recent call last):
  File "my_bot.py", line 5, in my_handler
    await event.message.answer("a" * 5000)
ValueError: text должен быть меньше 4000 символов
```

### 2. Корректные флаги при перехвате ошибки в outer middleware

Если outer middleware перехватывала `HandlerException` и поглощала его (без `raise`), `handle()`
считал событие необработанным и логировал ложное `"Проигнорировано"` — хотя хендлер был найден
и запущен.

Исправлено в `_process_event`: при получении `HandlerException` флаги `_router_id` и `_is_handled`
выставляются в `data` до `raise`, поэтому они доступны для `handle()` даже если middleware
поглотила исключение.

**Поведение middleware по типам:**

| Тип middleware | Получает | Доступ к оригиналу |
|---|---|---|
| **Inner** (в декораторе хендлера) | RAW исключение | напрямую |
| **Router / Global outer** | `HandlerException` | `e.cause` |

### 3. Тесты (`tests/test_dispatcher.py`)

| Тест | Что проверяет |
|---|---|
| `test_handle_logs_handler_exception_with_str_and_cause` | Формат лога: `__str__` исключения + `exc_info=e.cause` |
| `test_outer_middleware_receives_handler_exception` | Outer middleware получает `HandlerException` с оригиналом в `.cause` |
| `test_inner_middleware_receives_raw_exception` | Inner middleware получает RAW исключение до обёртки |
| `test_outer_middleware_swallows_handler_exception_no_ignored_log` | При поглощении исключения middleware лог `"Проигнорировано"` не появляется |

## Закрывает

Fixes #139 — При ошибке отправки сообщения не возникает явного исключения

## Чеклист

- [x] `ruff check .` — без ошибок
- [x] `ruff format . --check` — без ошибок
- [x] `mypy maxapi` — без ошибок
- [x] `pytest -q` — 838 passed, 14 skipped
