### PR TITLE
chore: добавлено игнорирование папки .idea в .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -161,6 +161,6 @@ cython_debug/
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
-#.idea/
+.idea/
 .DS_Store
 examples/.DS_Store


### PR DESCRIPTION
При каждой доработке висят бесячие "unversioned files" и нюансами pyCharm (которые другим разработчикам вряд ли нужны)

<img width="395" height="292" alt="Screenshot 2026-05-25 at 15 06 27" src="https://github.com/user-attachments/assets/ad8313d7-ecec-4d5a-8cce-8817293d0b35" />

Включил игнорирование .idea/ дирректории