### PR TITLE
feat: добавлен менеджер контекстов

### DIFF
--- a/docs/guides/context.md
+++ b/docs/guides/context.md
@@ -42,6 +42,36 @@ async def age_handler(event: MessageCreated, context: MemoryContext):
 - `set_data(data)` — полностью заменить данные
 - `clear()` — очистить контекст и сбросить состояние
 
+## Получение контекста вне хендлера
+
+```python
+context = await dp.fsm.get_context(
+    chat_id=chat_id,
+    user_id=user_id,
+)
+```
+
+Для простых операций можно не получать объект контекста вручную:
+
+```python
+await dp.fsm.set_state(
+    chat_id=chat_id,
+    user_id=user_id,
+    state=Form.name,
+)
+await dp.fsm.update_data(
+    chat_id=chat_id,
+    user_id=user_id,
+    name="Макс",
+)
+data = await dp.fsm.get_data(chat_id=chat_id, user_id=user_id)
+await dp.fsm.clear(chat_id=chat_id, user_id=user_id)
+```
+
+Метод использует то же хранилище, TTL и LRU-кеш, что и обычная
+обработка событий. FSM manager доступен через `Dispatcher`: используйте
+`dp.fsm`, а не `router.fsm`.
+
 ## TTL для контекста
 
 Для автоматической очистки неактивных контекстов можно передать `ttl`

--- a/docs/guides/context.md
+++ b/docs/guides/context.md
@@ -38,14 +38,14 @@ async def age_handler(event: MessageCreated, context: MemoryContext):
 - `set_state(state)` — установить состояние (State или None для сброса)
 - `get_state()` — получить текущее состояние
 - `get_data()` — получить все данные контекста
-- `update_data(**kwargs)` — обновить данные
+- `update_data(**kwargs)` — обновить данные и вернуть актуальный словарь
 - `set_data(data)` — полностью заменить данные
 - `clear()` — очистить контекст и сбросить состояние
 
 ## Получение контекста вне хендлера
 
 ```python
-context = await dp.fsm.get_context(
+context = dp.fsm.get_context(
     chat_id=chat_id,
     user_id=user_id,
 )
@@ -63,6 +63,11 @@ await dp.fsm.update_data(
     chat_id=chat_id,
     user_id=user_id,
     name="Макс",
+)
+await dp.fsm.update_data(
+    chat_id=chat_id,
+    user_id=user_id,
+    data={"chat_id": "значение в данных"},
 )
 data = await dp.fsm.get_data(chat_id=chat_id, user_id=user_id)
 await dp.fsm.clear(chat_id=chat_id, user_id=user_id)

--- a/maxapi/context/__init__.py
+++ b/maxapi/context/__init__.py
@@ -1,9 +1,11 @@
 from ..context.state_machine import State, StatesGroup
 from .base import BaseContext
 from .context import MemoryContext, RedisContext
+from .manager import ContextManager
 
 __all__ = [
     "BaseContext",
+    "ContextManager",
     "MemoryContext",
     "RedisContext",
     "State",

--- a/maxapi/context/base.py
+++ b/maxapi/context/base.py
@@ -39,8 +39,8 @@ class BaseContext(ABC):
         """Полностью заменяет контекст данных."""
 
     @abstractmethod
-    async def update_data(self, **kwargs: Any) -> None:
-        """Обновляет контекст данных новыми значениями."""
+    async def update_data(self, **kwargs: Any) -> dict[str, Any]:
+        """Обновляет данные и возвращает актуальный контекст."""
 
     @abstractmethod
     async def set_state(self, state: State | str | None = None) -> None:

--- a/maxapi/context/context.py
+++ b/maxapi/context/context.py
@@ -51,18 +51,22 @@ class MemoryContext(BaseContext):
             self._context = data
             self._ttl_tracker.touch()
 
-    async def update_data(self, **kwargs: Any) -> None:
+    async def update_data(self, **kwargs: Any) -> dict[str, Any]:
         """
         Обновляет контекст данных новыми значениями.
 
         Args:
             **kwargs: Пары ключ-значение для обновления
+
+        Returns:
+            Актуальный словарь данных.
         """
 
         async with self._lock:
             await self._expire_if_needed()
             self._context.update(kwargs)
             self._ttl_tracker.touch()
+            return self._context.copy()
 
     async def set_state(self, state: State | str | None = None) -> None:
         """
@@ -142,9 +146,12 @@ class RedisContext(BaseContext):
             await self.redis.set(self.data_key, payload, px=ttl_ms)
             await self.redis.pexpire(self.state_key, ttl_ms)
 
-    async def update_data(self, **kwargs: Any) -> None:
+    async def update_data(self, **kwargs: Any) -> dict[str, Any]:
         """
-        Атомарно обновляет данные
+        Атомарно обновляет данные.
+
+        Returns:
+            Актуальный словарь данных.
         """
         lua_script = """
         local data = redis.call('get', KEYS[1])
@@ -161,10 +168,10 @@ class RedisContext(BaseContext):
         else
             redis.call('set', KEYS[1], cjson.encode(decoded))
         end
-        return redis.status_reply("OK")
+        return cjson.encode(decoded)
         """
         ttl_ms = _ttl_to_ms(self.ttl)
-        await self.redis.eval(
+        result = await self.redis.eval(
             lua_script,
             1,
             self.data_key,
@@ -173,6 +180,9 @@ class RedisContext(BaseContext):
         )
         if ttl_ms is not None:
             await self.redis.pexpire(self.state_key, ttl_ms)
+        if isinstance(result, bytes):
+            result = result.decode("utf-8")
+        return json.loads(result) if result else {}
 
     async def set_state(self, state: State | str | None = None) -> None:
         if state is None:

--- a/maxapi/context/manager.py
+++ b/maxapi/context/manager.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from typing import Any
+
+    from ..dispatcher import Dispatcher
+    from .base import BaseContext
+    from .state_machine import State
+
+
+class ContextManager:
+    """
+    Высокоуровневый доступ к контекстам диспетчера.
+    """
+
+    def __init__(
+        self,
+        dispatcher: Dispatcher,
+        context_getter: Callable[[int | None, int | None], BaseContext],
+    ) -> None:
+        self.dispatcher = dispatcher
+        self._context_getter = context_getter
+
+    def _get_context(
+        self, chat_id: int | None, user_id: int | None
+    ) -> BaseContext:
+        """Возвращает контекст по идентификаторам."""
+        return self._context_getter(chat_id, user_id)
+
+    async def get_context(
+        self,
+        *,
+        chat_id: int | None,
+        user_id: int | None,
+    ) -> BaseContext:
+        """
+        Возвращает контекст пользователя по идентификаторам.
+
+        Args:
+            chat_id: Идентификатор чата.
+            user_id: Идентификатор пользователя.
+
+        Returns:
+            Контекст.
+        """
+        return self._get_context(chat_id, user_id)
+
+    async def set_state(
+        self,
+        *,
+        chat_id: int | None,
+        user_id: int | None,
+        state: State | str | None = None,
+    ) -> None:
+        """
+        Устанавливает состояние пользователя.
+
+        Args:
+            chat_id: Идентификатор чата.
+            user_id: Идентификатор пользователя.
+            state: Новое состояние или None для сброса.
+        """
+        context = self._get_context(chat_id, user_id)
+        await context.set_state(state)
+
+    async def get_state(
+        self, *, chat_id: int | None, user_id: int | None
+    ) -> State | str | None:
+        """
+        Возвращает состояние пользователя.
+
+        Args:
+            chat_id: Идентификатор чата.
+            user_id: Идентификатор пользователя.
+
+        Returns:
+            Текущее состояние или None.
+        """
+        context = self._get_context(chat_id, user_id)
+        return await context.get_state()
+
+    async def set_data(
+        self,
+        *,
+        chat_id: int | None,
+        user_id: int | None,
+        data: dict[str, Any],
+    ) -> None:
+        """
+        Полностью заменяет данные пользователя.
+
+        Args:
+            chat_id: Идентификатор чата.
+            user_id: Идентификатор пользователя.
+            data: Новый словарь контекста.
+        """
+        context = self._get_context(chat_id, user_id)
+        await context.set_data(data)
+
+    async def get_data(
+        self, *, chat_id: int | None, user_id: int | None
+    ) -> dict[str, Any]:
+        """
+        Возвращает данные пользователя.
+
+        Args:
+            chat_id: Идентификатор чата.
+            user_id: Идентификатор пользователя.
+
+        Returns:
+            Словарь с данными контекста.
+        """
+        context = self._get_context(chat_id, user_id)
+        return await context.get_data()
+
+    async def update_data(
+        self, *, chat_id: int | None, user_id: int | None, **kwargs: Any
+    ) -> dict[str, Any]:
+        """
+        Обновляет данные пользователя.
+
+        Args:
+            chat_id: Идентификатор чата.
+            user_id: Идентификатор пользователя.
+            **kwargs: Пары ключ-значение для обновления.
+        """
+        context = self._get_context(chat_id, user_id)
+        await context.update_data(**kwargs)
+        return await context.get_data()
+
+    async def clear(self, *, chat_id: int | None, user_id: int | None) -> None:
+        """
+        Очищает данные и состояние пользователя.
+
+        Args:
+            chat_id: Идентификатор чата.
+            user_id: Идентификатор пользователя.
+        """
+        context = self._get_context(chat_id, user_id)
+        await context.clear()

--- a/maxapi/context/manager.py
+++ b/maxapi/context/manager.py
@@ -30,7 +30,7 @@ class ContextManager:
         """Возвращает контекст по идентификаторам."""
         return self._context_getter(chat_id, user_id)
 
-    async def get_context(
+    def get_context(
         self,
         *,
         chat_id: int | None,
@@ -117,7 +117,12 @@ class ContextManager:
         return await context.get_data()
 
     async def update_data(
-        self, *, chat_id: int | None, user_id: int | None, **kwargs: Any
+        self,
+        *,
+        chat_id: int | None,
+        user_id: int | None,
+        data: dict[str, Any] | None = None,
+        **kwargs: Any,
     ) -> dict[str, Any]:
         """
         Обновляет данные пользователя.
@@ -125,11 +130,16 @@ class ContextManager:
         Args:
             chat_id: Идентификатор чата.
             user_id: Идентификатор пользователя.
+            data: Словарь значений для обновления.
             **kwargs: Пары ключ-значение для обновления.
+
+        Returns:
+            Актуальный словарь данных.
         """
         context = self._get_context(chat_id, user_id)
-        await context.update_data(**kwargs)
-        return await context.get_data()
+        update = dict(data or {})
+        update.update(kwargs)
+        return await context.update_data(**update)
 
     async def clear(self, *, chat_id: int | None, user_id: int | None) -> None:
         """

--- a/maxapi/dispatcher.py
+++ b/maxapi/dispatcher.py
@@ -13,7 +13,7 @@ from warnings import warn
 
 from aiohttp import ClientConnectorError
 
-from .context import BaseContext, MemoryContext
+from .context import BaseContext, ContextManager, MemoryContext
 from .enums.update import UpdateType
 from .exceptions.dispatcher import HandlerException, MiddlewareException
 from .exceptions.max import InvalidToken, MaxApiError, MaxConnection
@@ -116,6 +116,7 @@ class Dispatcher(BotMixin):
         self.router_id = router_id
         self.storage = storage
         self.storage_kwargs = storage_kwargs
+        self._fsm = ContextManager(self, self.__get_context)
 
         self.event_handlers: list[Handler] = []
         self.handlers_by_type: dict[UpdateType, list[Handler]] | None = None
@@ -197,6 +198,13 @@ class Dispatcher(BotMixin):
             update_type=UpdateType.USER_REMOVED, router=self
         )
         self.on_started = Event(update_type=UpdateType.ON_STARTED, router=self)
+
+    @property
+    def fsm(self) -> ContextManager:
+        """
+        Менеджер FSM-контекстов диспетчера.
+        """
+        return self._fsm
 
     @property
     def middlewares(self) -> list[BaseMiddleware]:
@@ -510,7 +518,7 @@ class Dispatcher(BotMixin):
             user_id: Идентификатор пользователя.
 
         Returns:
-            BaseContext: Контекст.
+            Контекст.
         """
 
         key = (chat_id, user_id)
@@ -1261,6 +1269,7 @@ class Dispatcher(BotMixin):
 
             kwargs: dict[str, Any] = {
                 "context": memory_context,
+                "state": memory_context,
                 "raw_state": current_state,
                 "_memory_context": memory_context,
                 "_current_state": current_state,
@@ -1538,6 +1547,14 @@ class Router(Dispatcher):
         """
 
         super().__init__(router_id)
+
+    @property
+    def fsm(self) -> ContextManager:
+        """
+        Роутер не владеет FSM-хранилищем.
+        """
+        msg = "Router не владеет FSM-хранилищем. Используйте dp.fsm."
+        raise RuntimeError(msg)
 
 
 class Event:

--- a/maxapi/dispatcher.py
+++ b/maxapi/dispatcher.py
@@ -1269,7 +1269,6 @@ class Dispatcher(BotMixin):
 
             kwargs: dict[str, Any] = {
                 "context": memory_context,
-                "state": memory_context,
                 "raw_state": current_state,
                 "_memory_context": memory_context,
                 "_current_state": current_state,

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -98,12 +98,15 @@ class TestMemoryContext:
     async def test_update_data(self, sample_context):
         """Тест обновления данных."""
         await sample_context.set_data({"key1": "value1"})
-        await sample_context.update_data(key2="value2", key3=123)
+        updated_data = await sample_context.update_data(
+            key2="value2", key3=123
+        )
 
         data = await sample_context.get_data()
         assert data["key1"] == "value1"
         assert data["key2"] == "value2"
         assert data["key3"] == 123
+        assert updated_data == data
 
     async def test_get_state_none(self, sample_context):
         """Тест получения состояния (изначально None)."""
@@ -306,6 +309,9 @@ class TestRedisContext:
     async def test_redis_update_data(self):
         """update_data вызывает Lua-обновление и продлевает TTL."""
         redis = AsyncMock()
+        redis.eval.return_value = json.dumps(
+            {"food": "mint", "city": "Samara"}
+        )
         context = RedisContext(
             chat_id=1,
             user_id=2,
@@ -313,7 +319,7 @@ class TestRedisContext:
             ttl=1.25,
         )
 
-        await context.update_data(food="mint", city="Samara")
+        updated_data = await context.update_data(food="mint", city="Samara")
 
         redis.eval.assert_awaited_once()
         _, keys_count, key, payload, ttl_ms = redis.eval.await_args.args
@@ -321,6 +327,7 @@ class TestRedisContext:
         assert key == context.data_key
         assert json.loads(payload) == {"food": "mint", "city": "Samara"}
         assert ttl_ms == "1250"
+        assert updated_data == {"food": "mint", "city": "Samara"}
         redis.pexpire.assert_awaited_once_with(context.state_key, 1250)
 
     async def test_redis_update_data_without_ttl(self):
@@ -329,9 +336,12 @@ class TestRedisContext:
         pexpire при этом не вызывается.
         """
         redis = AsyncMock()
+        redis.eval.return_value = json.dumps(
+            {"food": "mint", "city": "Samara"}
+        )
         context = RedisContext(chat_id=1, user_id=2, redis_client=redis)
 
-        await context.update_data(food="mint", city="Samara")
+        updated_data = await context.update_data(food="mint", city="Samara")
 
         redis.eval.assert_awaited_once()
         _, keys_count, key, payload, ttl_arg = redis.eval.await_args.args
@@ -342,6 +352,7 @@ class TestRedisContext:
             "ARGV[2] должен быть пустой строкой, "
             "чтобы Lua не входила в ветку PX"
         )
+        assert updated_data == {"food": "mint", "city": "Samara"}
         redis.pexpire.assert_not_awaited()
 
     async def test_redis_set_state_none(self):

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -271,9 +271,9 @@ class TestDispatcherContext:
         assert context1 is not context2
         assert len(dispatcher.contexts) == 2
 
-    async def test_fsm_get_context_by_ids(self, dispatcher):
+    def test_fsm_get_context_by_ids(self, dispatcher):
         """dp.fsm.get_context возвращает контекст по идентификаторам."""
-        context = await dispatcher.fsm.get_context(
+        context = dispatcher.fsm.get_context(
             chat_id=12345,
             user_id=67890,
         )
@@ -337,6 +337,23 @@ class TestDispatcherContext:
             )
             == {}
         )
+
+    async def test_fsm_manager_update_data_accepts_reserved_keys(
+        self, dispatcher
+    ):
+        """data позволяет записывать ключи, занятые параметрами helper."""
+        updated_data = await dispatcher.fsm.update_data(
+            chat_id=12345,
+            user_id=67890,
+            data={"chat_id": "stored", "user_id": "stored"},
+            name="Max",
+        )
+
+        assert updated_data == {
+            "chat_id": "stored",
+            "user_id": "stored",
+            "name": "Max",
+        }
 
     def test_get_memory_context_recreates_expired_context(self):
         """Просроченный context не должен переиспользоваться."""

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -6,7 +6,7 @@ from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 from maxapi.bot import Bot
-from maxapi.context import MemoryContext
+from maxapi.context import ContextManager, MemoryContext
 from maxapi.dispatcher import Dispatcher, Event, Router
 from maxapi.enums.update import UpdateType
 from maxapi.filters import F
@@ -32,6 +32,8 @@ class TestDispatcherInitialization:
         assert isinstance(dp.contexts, dict)
         assert isinstance(dp.routers, list)
         assert isinstance(dp.outer_middlewares, list)
+        assert isinstance(dp.fsm, ContextManager)
+        assert dp.fsm.dispatcher is dp
         assert dp.bot is None
         assert dp.polling is False
 
@@ -268,6 +270,73 @@ class TestDispatcherContext:
 
         assert context1 is not context2
         assert len(dispatcher.contexts) == 2
+
+    async def test_fsm_get_context_by_ids(self, dispatcher):
+        """dp.fsm.get_context возвращает контекст по идентификаторам."""
+        context = await dispatcher.fsm.get_context(
+            chat_id=12345,
+            user_id=67890,
+        )
+
+        assert isinstance(context, MemoryContext)
+        assert context is dispatcher._Dispatcher__get_context(12345, 67890)
+
+    def test_router_fsm_is_not_available(self):
+        """router.fsm явно запрещён, чтобы не создать отдельное хранилище."""
+        router = Router()
+
+        with pytest.raises(RuntimeError, match=r"Используйте dp\.fsm"):
+            _ = router.fsm
+
+        assert router.contexts == {}
+
+    async def test_fsm_manager_context_methods(self, dispatcher):
+        """dp.fsm проксирует основные методы контекста."""
+        await dispatcher.fsm.set_state(
+            chat_id=12345,
+            user_id=67890,
+            state="Form:name",
+        )
+        await dispatcher.fsm.set_data(
+            chat_id=12345,
+            user_id=67890,
+            data={"name": "Max"},
+        )
+        updated_data = await dispatcher.fsm.update_data(
+            chat_id=12345,
+            user_id=67890,
+            age=7,
+        )
+
+        state = await dispatcher.fsm.get_state(
+            chat_id=12345,
+            user_id=67890,
+        )
+        data = await dispatcher.fsm.get_data(
+            chat_id=12345,
+            user_id=67890,
+        )
+
+        assert state == "Form:name"
+        assert data == {"name": "Max", "age": 7}
+        assert updated_data == data
+
+        await dispatcher.fsm.clear(chat_id=12345, user_id=67890)
+
+        assert (
+            await dispatcher.fsm.get_state(
+                chat_id=12345,
+                user_id=67890,
+            )
+            is None
+        )
+        assert (
+            await dispatcher.fsm.get_data(
+                chat_id=12345,
+                user_id=67890,
+            )
+            == {}
+        )
 
     def test_get_memory_context_recreates_expired_context(self):
         """Просроченный context не должен переиспользоваться."""
@@ -824,6 +893,25 @@ class TestHandlePipeline:
         await dispatcher.handle(fixture_message_created)
 
         assert handled == [(fixture_message_created, Form.name)]
+
+    async def test_handle_injects_state_alias(
+        self, dispatcher, bot, fixture_message_created
+    ):
+        """Хендлер может принять FSM-контекст как state."""
+        states = []
+
+        @dispatcher.message_created()
+        async def _handler(event: MessageCreated, state: MemoryContext):
+            states.append(state)
+
+        _setup_for_handle(dispatcher, bot)
+        await dispatcher.handle(fixture_message_created)
+
+        assert states == [
+            dispatcher._Dispatcher__get_context(
+                *fixture_message_created.get_ids()
+            )
+        ]
 
     async def test_handle_catches_handler_exception(
         self, dispatcher, bot, fixture_message_created

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -894,25 +894,6 @@ class TestHandlePipeline:
 
         assert handled == [(fixture_message_created, Form.name)]
 
-    async def test_handle_injects_state_alias(
-        self, dispatcher, bot, fixture_message_created
-    ):
-        """Хендлер может принять FSM-контекст как state."""
-        states = []
-
-        @dispatcher.message_created()
-        async def _handler(event: MessageCreated, state: MemoryContext):
-            states.append(state)
-
-        _setup_for_handle(dispatcher, bot)
-        await dispatcher.handle(fixture_message_created)
-
-        assert states == [
-            dispatcher._Dispatcher__get_context(
-                *fixture_message_created.get_ids()
-            )
-        ]
-
     async def test_handle_catches_handler_exception(
         self, dispatcher, bot, fixture_message_created
     ):


### PR DESCRIPTION

## Описание

Добавлен публичный API для работы с FSM-контекстом вне хендлеров через `dp.fsm`.

Теперь контекст пользователя можно получить или изменить по `chat_id` и `user_id` без обращения к внутренним методам диспетчера:

- `dp.fsm.get_context(...)`
- `dp.fsm.get_state(...)`
- `dp.fsm.set_state(...)`
- `dp.fsm.get_data(...)`
- `dp.fsm.set_data(...)`
- `dp.fsm.update_data(...)`
- `dp.fsm.clear(...)`

Также `update_data()` теперь возвращает актуальный словарь данных после обновления.