### PR TITLE
feat: соответствие swagger 0.0.32

### DIFF
--- a/maxapi/bot.py
+++ b/maxapi/bot.py
@@ -499,6 +499,10 @@ class Bot(BaseConnection):
         """
         Удаляет чат.
 
+        .. deprecated:: 1.1.0
+            Метод удалён из официальной swagger-спецификации API MAX.
+            Использование не рекомендуется.
+
         https://dev.max.ru/docs-api/methods/DELETE/chats/-chatId-
 
         Args:
@@ -507,6 +511,14 @@ class Bot(BaseConnection):
         Returns:
             DeletedChat: Результат удаления чата.
         """
+
+        warnings.warn(
+            "bot.delete_chat() устарел и отсутствует в официальной "
+            "swagger-спецификации API MAX. "
+            "Использование не рекомендуется.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
 
         return await DeleteChat(
             bot=self,
@@ -647,6 +659,11 @@ class Bot(BaseConnection):
         """
         Получает список чатов бота.
 
+        .. deprecated:: 1.1.0
+            Начиная с июня 2026 года метод ``GET /chats`` больше не
+            поддерживается. API не предоставляет готового способа получить
+            список групповых чатов и каналов, в которые добавлен бот.
+
         https://dev.max.ru/docs-api/methods/GET/chats
 
         Args:
@@ -658,6 +675,15 @@ class Bot(BaseConnection):
         Returns:
             Chats: Список чатов.
         """
+
+        warnings.warn(
+            "bot.get_chats() устарел: начиная с июня 2026 года "
+            "GET /chats больше не поддерживается. API не предоставляет "
+            "готового способа получить список групповых чатов и каналов, "
+            "в которые добавлен бот.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
 
         return await GetChats(bot=self, count=count, marker=marker).fetch()
 

--- a/maxapi/bot.py
+++ b/maxapi/bot.py
@@ -519,19 +519,23 @@ class Bot(BaseConnection):
         message_ids: list[str] | None = None,
         from_time: datetime | int | None = None,
         to_time: datetime | int | None = None,
-        count: int = 50,
+        count: int | None = 50,
     ) -> Messages:
         """
-        Получает сообщения из чата.
+        Получает сообщения из чата или по списку идентификаторов.
+
+        Нужно передать ровно один из параметров: `chat_id`
+        или `message_ids`.
 
         https://dev.max.ru/docs-api/methods/GET/messages
 
         Args:
-            chat_id: ID чата.
-            message_ids: ID сообщений.
+            chat_id: ID чата, из которого нужно получить сообщения.
+            message_ids: ID сообщений, которые нужно получить.
             from_time: Начало периода.
             to_time: Конец периода.
-            count: Количество сообщений.
+            count: Количество сообщений. Если None, параметр
+                не отправляется.
 
         Returns:
             Messages: Список сообщений.
@@ -659,12 +663,12 @@ class Bot(BaseConnection):
 
     async def get_chat_by_link(self, link: str) -> Chat:
         """
-        Получает чат по ссылке.
+        Получает канал по публичной ссылке или алиасу.
 
         https://dev.max.ru/docs-api/methods/GET/chats/-chatLink-
 
         Args:
-            link: Ссылка на чат.
+            link: Публичная ссылка или алиас канала.
 
         Returns:
             Chat: Объект чата.

--- a/maxapi/methods/delete_chat.py
+++ b/maxapi/methods/delete_chat.py
@@ -1,3 +1,4 @@
+import warnings
 from typing import TYPE_CHECKING, cast
 
 from ..connection.base import BaseConnection
@@ -13,6 +14,10 @@ class DeleteChat(BaseConnection):
     """
     Класс для удаления чата через API.
 
+    .. deprecated:: 1.1.0
+        Метод удалён из официальной swagger-спецификации API MAX.
+        Использование не рекомендуется.
+
     https://dev.max.ru/docs-api/methods/DELETE/chats/-chatId-
 
     Attributes:
@@ -21,6 +26,14 @@ class DeleteChat(BaseConnection):
     """
 
     def __init__(self, bot: "Bot", chat_id: int):
+        warnings.warn(
+            "DeleteChat устарел и отсутствует в официальной "
+            "swagger-спецификации API MAX. "
+            "Использование не рекомендуется.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
         super().__init__()
         self.bot = bot
         self.chat_id = chat_id

--- a/maxapi/methods/get_chat_by_link.py
+++ b/maxapi/methods/get_chat_by_link.py
@@ -1,5 +1,6 @@
-from re import findall
+from re import fullmatch
 from typing import TYPE_CHECKING, cast
+from urllib.parse import urlparse
 
 from ..connection.base import BaseConnection
 from ..enums.api_path import ApiPath
@@ -12,12 +13,12 @@ if TYPE_CHECKING:
 
 class GetChatByLink(BaseConnection):
     """
-    Класс для получения информации о чате по ссылке.
+    Класс для получения информации о канале по публичной ссылке.
 
     https://dev.max.ru/docs-api/methods/GET/chats/-chatLink-
 
     Attributes:
-        link: Список валидных частей ссылки.
+        link: Нормализованная публичная ссылка.
         PATTERN_LINK: Регулярное выражение для парсинга ссылки.
     """
 
@@ -26,14 +27,24 @@ class GetChatByLink(BaseConnection):
     def __init__(self, bot: "Bot", link: str):
         super().__init__()
         self.bot = bot
-        self.link = findall(self.PATTERN_LINK, link)
+        self.link = self._normalize_link(link)
 
-        if not self.link:
+        if fullmatch(self.PATTERN_LINK, self.link) is None:
             raise ValueError(f"link не соответствует {self.PATTERN_LINK!r}")
+
+    @staticmethod
+    def _normalize_link(link: str) -> str:
+        value = link.strip()
+        parsed = urlparse(value)
+
+        if parsed.scheme or parsed.netloc:
+            value = parsed.path.rstrip("/").rsplit("/", maxsplit=1)[-1]
+
+        return value
 
     async def fetch(self) -> Chat:
         """
-        Выполняет GET-запрос для получения данных чата по ссылке.
+        Выполняет GET-запрос для получения данных канала по ссылке.
 
         Returns:
             Chat: Объект с информацией о чате.
@@ -43,7 +54,7 @@ class GetChatByLink(BaseConnection):
 
         response = await super().request(
             method=HTTPMethod.GET,
-            path=ApiPath.CHATS.value + "/" + self.link[-1],
+            path=ApiPath.CHATS.value + "/" + self.link,
             model=Chat,
             params=bot.params,
         )

--- a/maxapi/methods/get_chats.py
+++ b/maxapi/methods/get_chats.py
@@ -1,3 +1,4 @@
+import warnings
 from typing import TYPE_CHECKING, cast
 
 from ..connection.base import BaseConnection
@@ -12,6 +13,11 @@ if TYPE_CHECKING:
 class GetChats(BaseConnection):
     """
     Класс для получения списка чатов.
+
+    .. deprecated:: 1.1.0
+        Начиная с июня 2026 года метод ``GET /chats`` больше не
+        поддерживается. API не предоставляет готового способа получить
+        список групповых чатов и каналов, в которые добавлен бот.
 
     https://dev.max.ru/docs-api/methods/GET/chats
 
@@ -28,6 +34,15 @@ class GetChats(BaseConnection):
         count: int | None = None,
         marker: int | None = None,
     ):
+        warnings.warn(
+            "GetChats устарел: начиная с июня 2026 года GET /chats "
+            "больше не поддерживается. API не предоставляет готового "
+            "способа получить список групповых чатов и каналов, "
+            "в которые добавлен бот.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
         if count is not None and not (1 <= count <= 100):
             raise ValueError("count не должен быть меньше 1 или больше 100")
 

--- a/maxapi/methods/get_messages.py
+++ b/maxapi/methods/get_messages.py
@@ -5,7 +5,6 @@ from ..connection.base import BaseConnection
 from ..enums.api_path import ApiPath
 from ..enums.http_method import HTTPMethod
 from ..types.message import Messages
-from ..utils.time import to_ms
 
 if TYPE_CHECKING:
     from ..bot import Bot
@@ -33,10 +32,18 @@ class GetMessages(BaseConnection):
         message_ids: list[str] | None = None,
         from_time: datetime | int | None = None,
         to_time: datetime | int | None = None,
-        count: int = 50,
+        count: int | None = 50,
     ):
         if count is not None and not (1 <= count <= 100):
             raise ValueError("count не должен быть меньше 1 или больше 100")
+
+        has_chat_id = chat_id is not None
+        has_message_ids = bool(message_ids)
+        if has_chat_id == has_message_ids:
+            raise ValueError(
+                "Нужно передать ровно один из параметров: "
+                "chat_id или message_ids"
+            )
 
         super().__init__()
         self.bot = bot
@@ -61,25 +68,26 @@ class GetMessages(BaseConnection):
 
         params = bot.params.copy()
 
-        if self.chat_id:
+        if self.chat_id is not None:
             params["chat_id"] = self.chat_id
 
         if self.message_ids:
             params["message_ids"] = ",".join(self.message_ids)
 
-        if self.from_time:
+        if self.from_time is not None:
             if isinstance(self.from_time, datetime):
-                params["from"] = to_ms(self.from_time)
+                params["from"] = int(self.from_time.timestamp())
             else:
                 params["from"] = self.from_time
 
-        if self.to_time:
+        if self.to_time is not None:
             if isinstance(self.to_time, datetime):
-                params["to"] = to_ms(self.to_time)
+                params["to"] = int(self.to_time.timestamp())
             else:
                 params["to"] = self.to_time
 
-        params["count"] = self.count
+        if self.count is not None:
+            params["count"] = self.count
 
         response = await super().request(
             method=HTTPMethod.GET,

--- a/maxapi/types/chats.py
+++ b/maxapi/types/chats.py
@@ -407,7 +407,7 @@ class Chat(
         message_ids: list[str] | None = None,
         from_time: datetime | int | None = None,
         to_time: datetime | int | None = None,
-        count: int = 50,
+        count: int | None = 50,
     ) -> Messages:
         """Получить историю сообщений текущего чата."""
 

--- a/maxapi/types/chats.py
+++ b/maxapi/types/chats.py
@@ -233,8 +233,6 @@ class Chat(
             ведется диалог. Может быть None.
         messages_count: Количество сообщений в чате.
             Может быть None.
-        chat_message_id: Идентификатор сообщения чата.
-            Может быть None.
         pinned_message: Закрепленное сообщение.
             Может быть None.
     """
@@ -253,7 +251,6 @@ class Chat(
     description: str | None = None
     dialog_with_user: User | None = None
     messages_count: int | None = None
-    chat_message_id: str | None = None
     pinned_message: Message | None = None
     _bot: Any | None = PrivateAttr(default=None)
 
@@ -425,7 +422,13 @@ class Chat(
         return await self._ensure_bot().delete_me_from_chat(self.chat_id)
 
     async def delete(self) -> DeletedChat:
-        """Удалить текущий чат."""
+        """
+        Удалить текущий чат.
+
+        .. deprecated:: 1.1.0
+            Метод удалён из официальной swagger-спецификации API MAX.
+            Использование не рекомендуется.
+        """
 
         return await self._ensure_bot().delete_chat(self.chat_id)
 

--- a/tests/get_chat_id.py
+++ b/tests/get_chat_id.py
@@ -1,11 +1,10 @@
 #!/usr/bin/env python
-"""Утилита для получения chat_id для тестов.
+"""Утилита для проверки chat_id для интеграционных тестов.
 
 Использование:
     python tests/get_chat_id.py
 """
 
-import asyncio
 import os
 import sys
 from pathlib import Path
@@ -23,30 +22,19 @@ try:
 except ImportError:
     sys.exit(1)
 
-# Core Stuff
-from maxapi import Bot
 
+def main() -> None:
+    """Проверяет наличие корректного TEST_CHAT_ID."""
+    chat_id = os.environ.get("TEST_CHAT_ID")
 
-async def main():
-    """Получает список чатов."""
-    token = os.environ.get("MAX_BOT_TOKEN")
-
-    if not token:
+    if chat_id is None:
         sys.exit(1)
-
-    bot = Bot(token=token)
 
     try:
-        chats = await bot.get_chats(count=10)
-
-        if not chats.chats or len(chats.chats) == 0:
-            return
-
-    except Exception:
+        int(chat_id)
+    except ValueError:
         sys.exit(1)
-    finally:
-        await bot.close_session()
 
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    main()

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -237,6 +237,36 @@ class TestBotMethods:
             assert mock_fetch.called
 
     @pytest.mark.asyncio
+    async def test_delete_chat_is_deprecated(self, bot):
+        """Тест предупреждения для удалённого из swagger метода."""
+        from maxapi.methods.delete_chat import DeleteChat
+
+        with patch.object(
+            DeleteChat, "fetch", new_callable=AsyncMock
+        ) as mock_fetch:
+            mock_fetch.return_value = Mock()
+
+            with pytest.deprecated_call(match="delete_chat"):
+                await bot.delete_chat(chat_id=12345)
+
+            mock_fetch.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_get_chats_is_deprecated(self, bot):
+        """Тест предупреждения для неподдерживаемого GET /chats."""
+        from maxapi.methods.get_chats import GetChats
+
+        with patch.object(
+            GetChats, "fetch", new_callable=AsyncMock
+        ) as mock_fetch:
+            mock_fetch.return_value = Mock()
+
+            with pytest.deprecated_call(match="GET /chats"):
+                await bot.get_chats(count=5)
+
+            mock_fetch.assert_awaited_once()
+
+    @pytest.mark.asyncio
     async def test_send_action_with_wrong_action_type(self, bot):
         """Тест вызова send_action с передачей неверного типа (не SenderAction, не str)."""  # noqa: E501
         # Core Stuff
@@ -301,14 +331,6 @@ class TestBotIntegration:
         subs = await integration_bot.get_subscriptions()
         assert subs is not None
         assert hasattr(subs, "subscriptions")
-
-    @pytest.mark.asyncio
-    @pytest.mark.integration
-    async def test_get_chats_integration(self, integration_bot):
-        """Интеграционный тест get_chats."""
-        chats = await integration_bot.get_chats(count=5)
-        assert chats is not None
-        assert hasattr(chats, "chats")
 
     @pytest.mark.asyncio
     async def test_close_session_cleanup(self, integration_bot):

--- a/tests/test_chats_timestamps.py
+++ b/tests/test_chats_timestamps.py
@@ -22,6 +22,11 @@ def test_convert_timestamps_none():
     assert chat.participants is None
 
 
+def test_chat_message_id_is_not_sdk_field():
+    """Поле chat_message_id отсутствует в актуальной модели Chat."""
+    assert "chat_message_id" not in Chat.model_fields
+
+
 def test_convert_timestamps_millis_to_datetime():
     # подготовим временные метки в миллисекундах
     now = datetime.now()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -17,25 +17,12 @@ pytestmark = pytest.mark.integration
 
 
 @pytest.fixture
-async def test_chat_id(integration_bot, test_chat_id_from_env):
+async def test_chat_id(test_chat_id_from_env):
     """Получение тестового chat_id.
 
-    Приоритет:
-    1. Из переменной окружения TEST_CHAT_ID (или .env файла)
-    2. Из первого чата в списке чатов бота
+    ID берётся из переменной окружения TEST_CHAT_ID или .env файла.
     """
-    # Сначала проверяем переменную окружения
-    if test_chat_id_from_env:
-        return test_chat_id_from_env
-
-    # Если не указан в окружении, пытаемся получить из списка чатов
-    try:
-        chats = await integration_bot.get_chats(count=1)
-        if chats.chats and len(chats.chats) > 0:
-            return chats.chats[0].chat_id
-        return None
-    except Exception:
-        return None
+    return test_chat_id_from_env
 
 
 class TestBotIntegration:
@@ -51,15 +38,6 @@ class TestBotIntegration:
         assert me.is_bot is True
         # _me устанавливается только в Dispatcher.check_me(), не в Bot.get_me()
         # Проверяем только корректность возвращаемых данных
-
-    @pytest.mark.asyncio
-    async def test_get_chats(self, integration_bot):
-        """Тест получения списка чатов."""
-        chats = await integration_bot.get_chats(count=5)
-
-        assert chats is not None
-        assert hasattr(chats, "chats")
-        assert isinstance(chats.chats, list)
 
     @pytest.mark.asyncio
     async def test_get_subscriptions(self, integration_bot):

--- a/tests/test_swagger_alignment.py
+++ b/tests/test_swagger_alignment.py
@@ -1,12 +1,19 @@
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, Mock, patch
+
 import pytest
+from maxapi.connection.base import BaseConnection
 from maxapi.enums.add_chat_members_error_code import AddChatMembersErrorCode
 from maxapi.enums.attachment import AttachmentType
 from maxapi.enums.chat_permission import ChatPermission
 from maxapi.enums.text_style import TextStyle
+from maxapi.methods.get_chat_by_link import GetChatByLink
+from maxapi.methods.get_messages import GetMessages
 from maxapi.methods.types.added_members_chat import AddedMembersChat
 from maxapi.types.attachments.attachment import ContactAttachmentPayload
 from maxapi.types.attachments.image import PhotoAttachmentRequestPayload
 from maxapi.types.attachments.video import Video
+from maxapi.types.chats import ChatMember
 from maxapi.types.message import MessageBody
 from maxapi.types.users import ChatAdmin, User
 from pydantic import ValidationError
@@ -53,15 +60,25 @@ def test_added_members_chat_error_code_enum_rejects_unknown_code():
 
 
 def test_chat_permission_accepts_swagger_admin_values():
-    assert (
-        ChatPermission.POST_EDIT_DELETE_MESSAGE.value
-        == "post_edit_delete_message"
-    )
-    assert ChatPermission.EDIT_MESSAGE.value == "edit_message"
-    assert ChatPermission.DELETE_MESSAGE.value == "delete_message"
+    swagger_values = {
+        "read_all_messages",
+        "add_remove_members",
+        "add_admins",
+        "change_chat_info",
+        "pin_message",
+        "write",
+        "can_call",
+        "edit_link",
+        "post_edit_delete_message",
+        "edit_message",
+        "delete_message",
+        "edit",
+        "delete",
+    }
 
-    assert ChatPermission.EDIT.value == "edit"
-    assert ChatPermission.DELETE.value == "delete"
+    assert {ChatPermission(value).value for value in swagger_values} == (
+        swagger_values
+    )
     assert ChatPermission.VIEW_STATS.value == "view_stats"
 
 
@@ -85,6 +102,139 @@ def test_user_and_chat_admin_keep_swagger_compat_fields():
 
     assert user.first_name == "Alice"
     assert admin.alias == "owner"
+
+
+def test_chat_member_accepts_swagger_fields_with_nullable_permissions():
+    member = ChatMember.model_validate(
+        {
+            "user_id": 1,
+            "first_name": "Alice",
+            "username": "alice",
+            "is_bot": False,
+            "last_activity_time": 0,
+            "last_access_time": 10,
+            "is_owner": False,
+            "is_admin": True,
+            "join_time": 20,
+            "permissions": None,
+            "alias": "moderator",
+        }
+    )
+
+    assert member.last_access_time == 10
+    assert member.is_owner is False
+    assert member.is_admin is True
+    assert member.join_time == 20
+    assert member.permissions is None
+    assert member.alias == "moderator"
+
+
+def test_get_messages_requires_chat_id_or_message_ids(bot):
+    with pytest.raises(ValueError, match="chat_id или message_ids"):
+        GetMessages(bot=bot)
+
+
+def test_get_messages_rejects_chat_id_with_message_ids(bot):
+    with pytest.raises(ValueError, match="chat_id или message_ids"):
+        GetMessages(bot=bot, chat_id=1, message_ids=["mid-1"])
+
+
+async def test_get_messages_sends_message_ids_as_comma_list(bot):
+    method = GetMessages(
+        bot=bot,
+        message_ids=["mid-1", "mid-2"],
+    )
+
+    with patch.object(
+        BaseConnection, "request", new=AsyncMock(return_value=Mock())
+    ) as mocked_request:
+        await method.fetch()
+
+    params = mocked_request.call_args.kwargs["params"]
+    assert params["message_ids"] == "mid-1,mid-2"
+    assert "chat_id" not in params
+
+
+async def test_get_messages_sends_datetime_bounds_as_unix_seconds(bot):
+    from_time = datetime(2026, 1, 2, 3, 4, 5, tzinfo=timezone.utc)
+    to_time = datetime(2026, 1, 3, 3, 4, 5, tzinfo=timezone.utc)
+    method = GetMessages(
+        bot=bot,
+        chat_id=1,
+        from_time=from_time,
+        to_time=to_time,
+    )
+
+    with patch.object(
+        BaseConnection, "request", new=AsyncMock(return_value=Mock())
+    ) as mocked_request:
+        await method.fetch()
+
+    params = mocked_request.call_args.kwargs["params"]
+    assert params["from"] == int(from_time.timestamp())
+    assert params["to"] == int(to_time.timestamp())
+
+
+async def test_get_messages_omits_none_count(bot):
+    method = GetMessages(bot=bot, chat_id=1, count=None)
+
+    with patch.object(
+        BaseConnection, "request", new=AsyncMock(return_value=Mock())
+    ) as mocked_request:
+        await method.fetch()
+
+    params = mocked_request.call_args.kwargs["params"]
+    assert "count" not in params
+
+
+@pytest.mark.parametrize(
+    ("link", "expected_path"),
+    [
+        ("channel", "/chats/channel"),
+        ("@channel", "/chats/@channel"),
+        ("https://max.ru/channel", "/chats/channel"),
+    ],
+)
+async def test_get_chat_by_link_normalizes_public_link(
+    bot,
+    link,
+    expected_path,
+):
+    method = GetChatByLink(bot=bot, link=link)
+
+    with patch.object(
+        BaseConnection, "request", new=AsyncMock(return_value=Mock())
+    ) as mocked_request:
+        await method.fetch()
+
+    assert mocked_request.call_args.kwargs["path"] == expected_path
+
+
+@pytest.mark.parametrize(
+    "link",
+    [
+        "",
+        "not a link",
+        "https://max.ru/",
+        "https://max.ru/channel/extra invalid",
+    ],
+)
+def test_get_chat_by_link_rejects_invalid_link(bot, link):
+    with pytest.raises(ValueError, match="link не соответствует"):
+        GetChatByLink(bot=bot, link=link)
+
+
+async def test_get_chat_by_link_keeps_valid_link_characters(bot):
+    method = GetChatByLink(bot=bot, link="channel-name_123")
+
+    with patch.object(
+        BaseConnection, "request", new=AsyncMock(return_value=Mock())
+    ) as mocked_request:
+        await method.fetch()
+
+    assert mocked_request.call_args.kwargs["path"] == (
+        "/chats/channel-name_123"
+    )
 
 
 def test_contact_payload_accepts_hash_and_nullable_vcf():


### PR DESCRIPTION
## Что изменено

- Привёл `get_messages` ближе к swagger 0.0.32:
  - теперь нужно передавать ровно один источник: `chat_id` или `message_ids`;
  - `message_ids` отправляются как comma-separated список;
  - `count=None` не отправляет параметр `count`;
  - `datetime` для `from_time` / `to_time` конвертируется в Unix seconds.
- Обновил `get_chat_by_link`:
  - метод нормализует публичную ссылку или алиас канала;
  - поддерживаются значения вроде `channel`, `@channel`, `https://max.ru/channel`;
  - невалидные ссылки отклоняются до запроса.
- Уточнил docstring-и `Bot.get_messages` и `Bot.get_chat_by_link`.
- Добавил регрессионные тесты на соответствие swagger 0.0.32.