### PR TITLE
fix(webhook): не терять фоновые задачи обработки обновлений

### DIFF
--- a/maxapi/webhook/aiohttp.py
+++ b/maxapi/webhook/aiohttp.py
@@ -57,6 +57,16 @@ class AiohttpMaxWebhook(BaseMaxWebhook):
         """
         await self._startup()
 
+    async def on_shutdown(self, app: "web.Application") -> None:
+        """Дождаться фоновых задач обработки при остановке приложения.
+
+        Добавьте в ``app.on_cleanup`` при подключении к
+        существующему приложению::
+
+            app.on_cleanup.append(webhook.on_shutdown)
+        """
+        await self._shutdown()
+
     def setup(self, app: "web.Application", path: str = DEFAULT_PATH) -> None:
         """Зарегистрировать маршрут вебхука в aiohttp-приложении."""
         from aiohttp import web  # noqa: PLC0415
@@ -93,6 +103,7 @@ class AiohttpMaxWebhook(BaseMaxWebhook):
 
         app = web.Application()
         app.on_startup.append(self.on_startup)
+        app.on_cleanup.append(self.on_shutdown)
         self.setup(app, path)
         return app
 

--- a/maxapi/webhook/base.py
+++ b/maxapi/webhook/base.py
@@ -99,9 +99,10 @@ class BaseMaxWebhook(ABC):
         if not task.cancelled():
             exc = task.exception()
             if exc is not None:
-                logger_dp.exception(
+                logger_dp.error(
                     "Необработанное исключение в фоновой задаче handle(): %r",
                     exc,
+                    exc_info=exc,
                 )
 
     async def _shutdown(self) -> None:

--- a/maxapi/webhook/base.py
+++ b/maxapi/webhook/base.py
@@ -47,6 +47,7 @@ class BaseMaxWebhook(ABC):
         self.dp = dp
         self.bot = bot
         self.secret = secret
+        self._background_tasks: set[asyncio.Task[Any]] = set()
         if not self.secret:
             logger_dp.warning(
                 "Webhook запущен без secret. Передайте secret= в "
@@ -79,11 +80,45 @@ class BaseMaxWebhook(ABC):
             return False
 
         if self.dp.use_create_task:
-            asyncio.create_task(self.dp.handle(event_object))
+            task = asyncio.create_task(self.dp.handle(event_object))
+            self._background_tasks.add(task)
+            task.add_done_callback(self._on_background_task_done)
         else:
             await self.dp.handle(event_object)
 
         return True
+
+    def _on_background_task_done(self, task: "asyncio.Task[Any]") -> None:
+        """Callback завершения фоновой задачи (``use_create_task=True``).
+
+        Удаляет задачу из пула и логирует необработанное исключение, если оно
+        есть. Без явного вызова ``task.exception()`` Python при сборке мусора
+        выдаст предупреждение *"Task exception was never retrieved"*.
+        """
+        self._background_tasks.discard(task)
+        if not task.cancelled():
+            exc = task.exception()
+            if exc is not None:
+                logger_dp.exception(
+                    "Необработанное исключение в фоновой задаче handle(): %r",
+                    exc,
+                )
+
+    async def _shutdown(self) -> None:
+        """Дождаться фоновых задач обработки (``use_create_task=True``).
+
+        Вызывается интеграциями при остановке приложения: без этого задачи,
+        запущенные из ``_dispatch``, обрываются вместе с event loop.
+        """
+        if not self._background_tasks:
+            return
+
+        logger_dp.info(
+            "Ожидаю завершения %d фоновых задач вебхука...",
+            len(self._background_tasks),
+        )
+        await asyncio.gather(*self._background_tasks, return_exceptions=True)
+        logger_dp.info("Все фоновые задачи вебхука завершены")
 
     @abstractmethod
     def create_app(self, path: str = DEFAULT_PATH):

--- a/maxapi/webhook/fastapi.py
+++ b/maxapi/webhook/fastapi.py
@@ -98,7 +98,10 @@ class FastAPIMaxWebhook(BaseMaxWebhook):
         ``contextlib.asynccontextmanager`` вручную.
         """
         await self._startup()
-        yield
+        try:
+            yield
+        finally:
+            await self._shutdown()
 
     def setup(self, app: "FastAPI", path: str = DEFAULT_PATH) -> None:
         """Зарегистрировать маршрут вебхука в FastAPI-приложении."""

--- a/maxapi/webhook/litestar.py
+++ b/maxapi/webhook/litestar.py
@@ -78,6 +78,18 @@ class LitestarMaxWebhook(BaseMaxWebhook):
         """
         await self._startup()
 
+    async def on_shutdown(self) -> None:
+        """Дождаться фоновых задач обработки при остановке приложения.
+
+        Передаётся в ``on_shutdown`` при ручной сборке приложения::
+
+            app = Litestar(
+                route_handlers=[...],
+                on_shutdown=[webhook.on_shutdown],
+            )
+        """
+        await self._shutdown()
+
     def make_handler(self, path: str = DEFAULT_PATH) -> "HTTPRouteHandler":
         """Вернуть настроенный POST-обработчик маршрута Litestar.
 
@@ -122,6 +134,7 @@ class LitestarMaxWebhook(BaseMaxWebhook):
         return Litestar(
             route_handlers=[self.make_handler(path)],
             on_startup=[self.on_startup],
+            on_shutdown=[self.on_shutdown],
         )
 
     async def run(

--- a/tests/test_webhook/test_background_tasks.py
+++ b/tests/test_webhook/test_background_tasks.py
@@ -1,0 +1,119 @@
+"""Тесты фоновых задач вебхука при ``use_create_task=True``.
+
+Задача, запущенная из ``_dispatch``, должна храниться в пуле диспетчера:
+``asyncio.create_task`` не владеет задачей, и без сильной ссылки сборщик
+мусора может забрать её до завершения обработки события. Пул также позволяет
+дождаться обработки при остановке приложения.
+"""
+
+import asyncio
+import gc
+
+import maxapi.webhook.base as base_module
+import pytest
+from maxapi import Dispatcher
+from maxapi.webhook.aiohttp import AiohttpMaxWebhook
+
+
+class DummyBot:
+    pass
+
+
+class DummyEvent:
+    update_type = "MESSAGE_CREATED"
+
+    def get_ids(self):
+        return (123, 456)
+
+
+@pytest.fixture
+def event(monkeypatch):
+    """process_update_webhook всегда отдаёт готовое событие."""
+    dummy = DummyEvent()
+
+    async def fake_process(event_json, bot):
+        return dummy
+
+    monkeypatch.setattr(base_module, "process_update_webhook", fake_process)
+    return dummy
+
+
+def _make_webhook(dp):
+    return AiohttpMaxWebhook(dp=dp, bot=DummyBot(), secret=None)
+
+
+async def test_dispatch_keeps_reference_to_background_task(event):
+    """Задача остаётся в пуле, пока обработка не завершилась."""
+    dp = Dispatcher(use_create_task=True)
+    release = asyncio.Event()
+
+    async def slow_handle(event_object):
+        await release.wait()
+
+    dp.handle = slow_handle
+    webhook = _make_webhook(dp)
+
+    assert await webhook._dispatch({"update_type": "message_created"}) is True
+    assert len(webhook._background_tasks) == 1
+
+    # Сборка мусора не должна забрать задачу: ссылка на неё есть в пуле.
+    gc.collect()
+    assert len(webhook._background_tasks) == 1
+
+    release.set()
+    await webhook._shutdown()
+    assert webhook._background_tasks == set()
+
+
+async def test_shutdown_waits_for_running_handlers(event):
+    """_shutdown() дожидается уже принятых обновлений."""
+    dp = Dispatcher(use_create_task=True)
+    finished = []
+
+    async def slow_handle(event_object):
+        await asyncio.sleep(0.01)
+        finished.append(event_object)
+
+    dp.handle = slow_handle
+    webhook = _make_webhook(dp)
+
+    for _ in range(3):
+        await webhook._dispatch({"update_type": "message_created"})
+
+    await webhook._shutdown()
+    assert len(finished) == 3
+    assert webhook._background_tasks == set()
+
+
+async def test_failed_background_task_is_logged_and_released(event, caplog):
+    """Упавшая задача не остаётся в пуле и её исключение не теряется."""
+    dp = Dispatcher(use_create_task=True)
+
+    async def failing_handle(event_object):
+        raise RuntimeError("обработчик упал")
+
+    dp.handle = failing_handle
+    webhook = _make_webhook(dp)
+
+    with caplog.at_level("ERROR"):
+        await webhook._dispatch({"update_type": "message_created"})
+        await webhook._shutdown()
+
+    assert webhook._background_tasks == set()
+    assert "обработчик упал" in caplog.text
+
+
+async def test_dispatch_awaits_handler_without_create_task(event):
+    """use_create_task=False: обработка идёт внутри запроса, как раньше."""
+    dp = Dispatcher()
+    handled = []
+
+    async def handle(event_object):
+        handled.append(event_object)
+
+    dp.handle = handle
+    webhook = _make_webhook(dp)
+
+    await webhook._dispatch({"update_type": "message_created"})
+    assert handled == [event]
+    assert webhook._background_tasks == set()


### PR DESCRIPTION
## Проблема

При `use_create_task=True` вебхук создаёт задачу и сразу забывает про неё
(`maxapi/webhook/base.py`):

```python
if self.dp.use_create_task:
    asyncio.create_task(self.dp.handle(event_object))
```

`asyncio.create_task` не владеет задачей — event loop держит только слабую
ссылку. Пока задача выполняется без прерываний, всё работает, но на первом же
`await` внутри `handle()` задачу может забрать сборщик мусора, и обработка
обновления оборвётся без единой записи в логе. По этой же причине теряется и
исключение из хендлера: без вызова `task.exception()` Python ограничивается
предупреждением *"Task exception was never retrieved"* при сборке мусора.

В polling-ветке диспетчера то же самое место сделано правильно
(`maxapi/dispatcher.py`):

```python
task = asyncio.create_task(self.handle(event))
self._background_tasks.add(task)
task.add_done_callback(self._on_background_task_done)
```

Дополнительно: у вебхука нет аналога `stop_polling()`, который дожидается
фоновых задач, поэтому при остановке приложения принятые обновления
обрываются вместе с event loop.

Это же ограничение — причина, по которой в `pyproject.toml` отключено правило
`RUF006` («Store a reference to the return value of `asyncio.create_task`») с
пометкой «требует рефакторинга». Патч закрывает случай в вебхуке; ещё два
места (`connection/base.py` и polling-ветка) остаются, поэтому правило пока не
включаю.

## Решение

- `BaseMaxWebhook` держит собственный пул задач и вешает done-callback с тем
  же логированием исключений, что и диспетчер;
- добавлен `_shutdown()`, который дожидается принятых обновлений;
- он вызывается в жизненном цикле всех трёх интеграций: `lifespan` у FastAPI,
  `on_cleanup` у aiohttp, `on_shutdown` у Litestar. У aiohttp и Litestar
  публичный хук `on_shutdown` парный к существующему `on_startup`, так что
  ручная сборка приложения выглядит симметрично.

Поведение при `use_create_task=False` (значение по умолчанию) не меняется.

## Тесты

`tests/test_webhook/test_background_tasks.py` — 4 теста:

- задача остаётся в пуле и переживает `gc.collect()`, пока обработка идёт;
- `_shutdown()` дожидается всех принятых обновлений;
- упавшая задача освобождает слот, её исключение логируется;
- при `use_create_task=False` обработка по-прежнему идёт внутри запроса.

Локально: `pytest -q` — 958 passed, 12 skipped; `mypy maxapi` — чисто;
`ruff format --check` — чисто.
