### PR TITLE
fix: устранена потеря path-префикса в кастомном api_url

### DIFF
--- a/maxapi/bot.py
+++ b/maxapi/bot.py
@@ -341,7 +341,6 @@ class Bot(BaseConnection):
         """
         if not self.session or self.session.closed:
             self.session = ClientSession(
-                base_url=self.api_url,
                 timeout=self.default_connection.timeout,
                 headers=self.headers,
                 **with_default_connector(self.default_connection.kwargs),

--- a/maxapi/connection/base.py
+++ b/maxapi/connection/base.py
@@ -119,7 +119,7 @@ class BaseConnection(BotMixin):
         self.bot: Bot | None = None
         self.session: ClientSession | None = None
         self.after_input_media_delay: float = self.AFTER_MEDIA_INPUT_DELAY
-        self.api_url = self.API_URL.rstrip("/")
+        self.api_url = self.API_URL
 
     def set_api_url(self, url: str) -> None:
         """

--- a/maxapi/connection/base.py
+++ b/maxapi/connection/base.py
@@ -119,7 +119,7 @@ class BaseConnection(BotMixin):
         self.bot: Bot | None = None
         self.session: ClientSession | None = None
         self.after_input_media_delay: float = self.AFTER_MEDIA_INPUT_DELAY
-        self.api_url = self.API_URL
+        self.api_url = self.API_URL.rstrip("/")
 
     def set_api_url(self, url: str) -> None:
         """
@@ -129,7 +129,7 @@ class BaseConnection(BotMixin):
             url: Новый API URL
         """
 
-        self.api_url = url
+        self.api_url = url.rstrip("/")
 
     async def request(
         self,
@@ -172,7 +172,7 @@ class BaseConnection(BotMixin):
         retry_statuses = conn.retry_on_statuses
 
         path_str = path.value if isinstance(path, ApiPath) else path
-        url = bot.api_url.rstrip("/") + path_str
+        url = bot.api_url + path_str
 
         @backoff.on_exception(
             backoff.expo,

--- a/maxapi/connection/base.py
+++ b/maxapi/connection/base.py
@@ -171,7 +171,8 @@ class BaseConnection(BotMixin):
         conn = bot.default_connection
         retry_statuses = conn.retry_on_statuses
 
-        url = path.value if isinstance(path, ApiPath) else path
+        path_str = path.value if isinstance(path, ApiPath) else path
+        url = bot.api_url.rstrip("/") + path_str
 
         @backoff.on_exception(
             backoff.expo,

--- a/tests/test_base_url_path_prefix.py
+++ b/tests/test_base_url_path_prefix.py
@@ -45,9 +45,7 @@ class TestRequestUrlWithCustomApiUrl:
         self, bot_with_mock_session
     ):
         """Path-префикс кастомного api_url не отбрасывается."""
-        bot_with_mock_session.set_api_url(
-            "https://stand.internal/gateway/v1"
-        )
+        bot_with_mock_session.set_api_url("https://stand.internal/gateway/v1")
 
         base = BaseConnection()
         base.bot = bot_with_mock_session
@@ -61,18 +59,14 @@ class TestRequestUrlWithCustomApiUrl:
         called_url = bot_with_mock_session.session.request.call_args.kwargs[
             "url"
         ]
-        assert (
-            called_url == "https://stand.internal/gateway/v1/messages"
-        )
+        assert called_url == "https://stand.internal/gateway/v1/messages"
 
     @pytest.mark.asyncio
     async def test_trailing_slash_in_api_url_does_not_double(
         self, bot_with_mock_session
     ):
         """Trailing slash в api_url не даёт двойной слэш в URL."""
-        bot_with_mock_session.set_api_url(
-            "https://stand.internal/gateway/v1/"
-        )
+        bot_with_mock_session.set_api_url("https://stand.internal/gateway/v1/")
 
         base = BaseConnection()
         base.bot = bot_with_mock_session

--- a/tests/test_base_url_path_prefix.py
+++ b/tests/test_base_url_path_prefix.py
@@ -1,0 +1,123 @@
+"""Тесты корректной сборки URL при кастомном api_url с path-префиксом.
+
+При использовании aiohttp.ClientSession(base_url=...) резолюция URL
+идёт по RFC 3986 §5.3: путь запроса, начинающийся с "/" (все значения
+ApiPath именно такие), считается absolute-path reference и заменяет
+весь path базового URL целиком, а не дописывается к нему. Из-за этого
+любой path-префикс в кастомном api_url (например, у прокси/шлюза на
+нестандартных стендах) молча отбрасывался. См. issue про
+set_api_url() с непустым path в базовом URL.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from maxapi import Bot
+from maxapi.connection.base import BaseConnection
+from maxapi.enums.api_path import ApiPath
+from maxapi.enums.http_method import HTTPMethod
+
+
+def _make_response(status=200, json_data=None):
+    """Создаёт мок aiohttp-ответа с async-методами."""
+    resp = MagicMock()
+    resp.status = status
+    resp.ok = 200 <= status < 300
+    resp.json = AsyncMock(return_value=json_data or {})
+    return resp
+
+
+class TestRequestUrlWithCustomApiUrl:
+    """Тесты сборки итогового URL в BaseConnection.request()."""
+
+    @pytest.fixture
+    def bot_with_mock_session(self, mock_bot_token):
+        """Бот с мок-сессией, готовой отдать успешный ответ."""
+        bot = Bot(token=mock_bot_token)
+        session = MagicMock()
+        session.closed = False
+        session.request = AsyncMock(return_value=_make_response())
+        bot.session = session
+        return bot
+
+    @pytest.mark.asyncio
+    async def test_path_prefix_in_api_url_is_preserved(
+        self, bot_with_mock_session
+    ):
+        """Path-префикс кастомного api_url не отбрасывается."""
+        bot_with_mock_session.set_api_url(
+            "https://stand.internal/gateway/v1"
+        )
+
+        base = BaseConnection()
+        base.bot = bot_with_mock_session
+
+        await base.request(
+            method=HTTPMethod.GET,
+            path=ApiPath.MESSAGES,
+            is_return_raw=True,
+        )
+
+        called_url = bot_with_mock_session.session.request.call_args.kwargs[
+            "url"
+        ]
+        assert (
+            called_url == "https://stand.internal/gateway/v1/messages"
+        )
+
+    @pytest.mark.asyncio
+    async def test_trailing_slash_in_api_url_does_not_double(
+        self, bot_with_mock_session
+    ):
+        """Trailing slash в api_url не даёт двойной слэш в URL."""
+        bot_with_mock_session.set_api_url(
+            "https://stand.internal/gateway/v1/"
+        )
+
+        base = BaseConnection()
+        base.bot = bot_with_mock_session
+
+        await base.request(
+            method=HTTPMethod.GET,
+            path=ApiPath.ME,
+            is_return_raw=True,
+        )
+
+        called_url = bot_with_mock_session.session.request.call_args.kwargs[
+            "url"
+        ]
+        assert called_url == "https://stand.internal/gateway/v1/me"
+
+    @pytest.mark.asyncio
+    async def test_default_api_url_unchanged(self, bot_with_mock_session):
+        """Без кастомного api_url поведение не меняется."""
+        base = BaseConnection()
+        base.bot = bot_with_mock_session
+
+        await base.request(
+            method=HTTPMethod.GET,
+            path=ApiPath.CHATS,
+            is_return_raw=True,
+        )
+
+        called_url = bot_with_mock_session.session.request.call_args.kwargs[
+            "url"
+        ]
+        assert called_url == bot_with_mock_session.api_url + "/chats"
+
+
+class TestEnsureSessionNoBaseUrl:
+    """ClientSession больше не должна создаваться с base_url."""
+
+    @pytest.mark.asyncio
+    async def test_ensure_session_omits_base_url(self, mock_bot_token):
+        """ensure_session() не передаёт base_url в ClientSession."""
+        bot = Bot(token=mock_bot_token)
+        bot.set_api_url("https://stand.internal/gateway/v1")
+        bot.session = None
+
+        with patch("maxapi.bot.ClientSession") as session_cls:
+            session_cls.return_value = MagicMock(closed=False)
+            await bot.ensure_session()
+
+        assert "base_url" not in session_cls.call_args.kwargs


### PR DESCRIPTION
  ## Проблема                                                                                                                                                                                                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                                                                                                                                                                                            
  `ensure_session()` создаёт `ClientSession(base_url=self.api_url, ...)`, а `request()`                                                                                                                                                                                                                                                                                                                                                     
  передаёт path из `ApiPath` как есть (все значения начинаются с `/`). aiohttp/yarl                                                                                                                                                                                                                                                                                                                                                         
  резолвит такой URL по RFC 3986 §5.3 как absolute-path reference - path базового URL                                                                                                                                                                                                                                                                                                                                                       
  отбрасывается целиком, остаётся только `scheme://host`                                                                                                                                                                                                                                                                                                                                                                                   
                                                                                                                                                                                                                                                                                                                                                                                                                                            
  Из-за этого кастомный `api_url`, заданный через `set_api_url()` и содержащий                                                                                                                                                                                                                                                                                                                                                              
  path-префикс (например, адрес внутреннего шлюза/прокси на нестандартных окружениях),                                                                                                                                                                                                                                                                                                                                                      
  при каждом запросе теряет этот префикс, и запрос улетает не туда (а у многих энтерпрайз компаний есть свои самописные   прокси для запросов во внешние сервисы, причем такие, что по одному домену с префиксом (типо /max, /tg и тп), работает одна прокся.                                                                                                                                                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                                                                                                                                                                            
  На дефолтном `API_URL` бага не видно, т.к. там пустой path - поэтому проявляется                                                                                                                                                                                                                                                                                                                                                          
  только на кастомных base_url с префиксом                                                                                                                                                                                                                                                                                                                                                                                                
                                                                                                                                                                                                                                                                                                                                                                                                                                            
  ## Фикс                                                                                                                                                                                                                                                                                                                                                                                                                                   
                                                                                                                                                                                                                                                                                                                                                                                                                                            
  - `ClientSession` больше не создаётся с `base_url=` - резолюция через aiohttp убрана                                                                                                                                                                                                                                                                                                                                                     
  - `request()` теперь сам собирает абсолютный URL: `bot.api_url.rstrip("/") + path`                                                                                                                                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                                                                                                                                                                            
  Оба изменения точечные, остальная логика (backoff-ретраи, retry_on_statuses,                                                                                                                                                                                                                                                                                                                                                              
  bind_bot, диспатч raw_api_response) не тронута                                                                                                                                                                                                                                                                                                                                                                  
  
   ## Тесты и тп
   
   Все проходит, все зеленое