### PR TITLE
fix #193: Раздельные предупреждения для нераспознанных обновлений

### DIFF
--- a/docs/types/updates/update.md
+++ b/docs/types/updates/update.md
@@ -8,3 +8,5 @@
         - UpdateUnion
         - UpdateUnionAdapter
         - UNKNOWN_UPDATE_DISCLAIMER
+        - MALFORMED_UPDATE_DISCLAIMER
+        - UNSUPPORTED_MESSAGE_UPDATE_DISCLAIMER

--- a/maxapi/methods/types/getted_updates.py
+++ b/maxapi/methods/types/getted_updates.py
@@ -1,8 +1,12 @@
-import logging
+import json
 from typing import TYPE_CHECKING, Any
 
+from ...enums.update import UpdateType
+from ...loggers import logger_dp
 from ...types.updates import (
+    MALFORMED_UPDATE_DISCLAIMER,
     UNKNOWN_UPDATE_DISCLAIMER,
+    UNSUPPORTED_MESSAGE_UPDATE_DISCLAIMER,
     UpdateUnion,
     UpdateUnionAdapter,
 )
@@ -11,11 +15,89 @@ from ...utils.updates import enrich_event
 if TYPE_CHECKING:
     from ...bot import Bot
 
-logger = logging.getLogger(__name__)
+_SERVICE_UPDATE_TYPES = frozenset(
+    {
+        UpdateType.ON_STARTED,
+        UpdateType.RAW_API_RESPONSE,
+    }
+)
+_KNOWN_UPDATE_TYPES = frozenset(UpdateType) - _SERVICE_UPDATE_TYPES
 
 
-async def get_update_model(event: dict, bot: "Bot") -> UpdateUnion | None:
-    """Конвертировать словарь с событием в модель обновления."""
+def _dump_event_json(event: dict[str, Any]) -> str:
+    """Сериализовать событие в однострочный JSON для лога.
+
+    Несериализуемые объекты (enum, datetime и т.п.) заменяются
+    строковым представлением.
+
+    Returns:
+        JSON-строка события или её строковое представление,
+        если событие не сериализуется.
+    """
+
+    try:
+        return json.dumps(event, ensure_ascii=False, default=str)
+    except (TypeError, ValueError):
+        return str(event)
+
+
+def warn_unprocessable_event(event: dict[str, Any]) -> None:
+    """Предупредить в лог о событии, которое не удалось разобрать.
+
+    Различает три случая: известную проблему на стороне MAX
+    (message_created без тела сообщения — например, голосовое
+    сообщение боту), известный тип события с некорректным
+    содержимым и неизвестный тип события. В лог всегда попадает
+    payload события, а в сообщении указано, куда обращаться.
+
+    Args:
+        event: Словарь события из ответа API или вебхука.
+    """
+
+    update_type = event.get("update_type")
+    event_json = _dump_event_json(event)
+
+    if update_type == UpdateType.MESSAGE_CREATED and "message" not in event:
+        logger_dp.warning(
+            UNSUPPORTED_MESSAGE_UPDATE_DISCLAIMER.format(
+                event_json=event_json,
+            )
+        )
+    elif update_type in _KNOWN_UPDATE_TYPES:
+        logger_dp.warning(
+            MALFORMED_UPDATE_DISCLAIMER.format(
+                update_type=update_type,
+                event_json=event_json,
+            )
+        )
+    else:
+        logger_dp.warning(
+            UNKNOWN_UPDATE_DISCLAIMER.format(
+                update_type=update_type,
+                event_json=event_json,
+            )
+        )
+
+
+async def get_update_model(
+    event: dict[str, Any], bot: "Bot"
+) -> UpdateUnion | None:
+    """Конвертировать словарь с событием в модель обновления.
+
+    При любой ошибке валидации (неизвестный тип события или
+    известный тип с некорректным содержимым) возвращает ``None``,
+    чтобы не ломать процесс получения обновлений. Классификацию
+    причины и предупреждение в лог выполняет вызывающий код через
+    :func:`warn_unprocessable_event`.
+
+    Args:
+        event: Словарь события из ответа API или вебхука.
+        bot: Экземпляр бота.
+
+    Returns:
+        Модель события или ``None``, если событие не распознано.
+    """
+
     try:
         event_object = UpdateUnionAdapter.validate_python(event)
     except ValueError:
@@ -31,16 +113,24 @@ async def process_update_request(
     events: dict[str, Any],
     bot: "Bot",
 ) -> list[UpdateUnion]:
-    """Конвертировать словарь с обновлениями в список моделей."""
+    """Конвертировать словарь с обновлениями в список моделей.
+
+    Нераспознанные события пропускаются с предупреждением в лог.
+
+    Args:
+        events: Ответ API метода GET /updates.
+        bot: Экземпляр бота.
+
+    Returns:
+        Список разобранных событий.
+    """
+
     events_models = []
 
     for event in events["updates"]:
         event_model = await get_update_model(event, bot)
         if event_model is None:
-            update_type = event["update_type"]
-            logger.warning(
-                UNKNOWN_UPDATE_DISCLAIMER.format(update_type=update_type)
-            )
+            warn_unprocessable_event(event)
             continue
 
         events_models.append(event_model)
@@ -51,4 +141,14 @@ async def process_update_request(
 async def process_update_webhook(
     event_json: dict[str, Any], bot: "Bot"
 ) -> UpdateUnion | None:
+    """Конвертировать JSON события вебхука в модель обновления.
+
+    Args:
+        event_json: Тело вебхук-запроса.
+        bot: Экземпляр бота.
+
+    Returns:
+        Модель события или ``None``, если событие не распознано.
+    """
+
     return await get_update_model(bot=bot, event=event_json)

--- a/maxapi/types/updates/__init__.py
+++ b/maxapi/types/updates/__init__.py
@@ -23,7 +23,28 @@ UNKNOWN_UPDATE_DISCLAIMER = (
     "Получен неизвестный тип обновления: {update_type}. "
     "Убедитесь, что используете актуальную версию maxapi. "
     "Если проблема сохраняется, создайте issue в репозитории проекта: "
-    "https://github.com/love-apples/maxapi/issues"
+    "https://github.com/love-apples/maxapi/issues "
+    "с описанием как воспроизвести проблему. "
+    "Payload события: {event_json}"
+)
+
+MALFORMED_UPDATE_DISCLAIMER = (
+    "Получено обновление известного типа '{update_type}' с "
+    "некорректным содержимым, оно будет пропущено. "
+    "Убедитесь, что используете актуальную версию maxapi. "
+    "Если проблема сохраняется, создайте issue в репозитории проекта: "
+    "https://github.com/love-apples/maxapi/issues "
+    "с описанием как воспроизвести проблему. "
+    "Payload события: {event_json}"
+)
+
+UNSUPPORTED_MESSAGE_UPDATE_DISCLAIMER = (
+    "Получено обновление известного типа 'message_created' с "
+    "некорректным содержимым, оно будет пропущено. "
+    "Это может быть неподдерживаемое сообщение на стороне MAX"
+    " — напишите в поддержку partner_support@max.ru "
+    "с описанием как воспроизвести проблему. "
+    "Payload события: {event_json}"
 )
 
 UpdateUnion = Annotated[

--- a/maxapi/webhook/base.py
+++ b/maxapi/webhook/base.py
@@ -12,8 +12,10 @@ from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any
 
 from ..loggers import logger_dp
-from ..methods.types.getted_updates import process_update_webhook
-from ..types.updates import UNKNOWN_UPDATE_DISCLAIMER
+from ..methods.types.getted_updates import (
+    process_update_webhook,
+    warn_unprocessable_event,
+)
 
 if TYPE_CHECKING:
     from ..bot import Bot
@@ -64,18 +66,20 @@ class BaseMaxWebhook(ABC):
         """Распарсить и диспетчеризовать входящее обновление.
 
         Преобразует сырой JSON-payload в типизированный объект
-        события и передаёт диспетчеру. При нераспознанном типе
-        обновления логирует предупреждение и возвращает ``False``.
+        события и передаёт диспетчеру. Если событие не удалось
+        разобрать (неизвестный тип или некорректное содержимое),
+        логирует предупреждение.
+
+        Returns:
+            ``True``, если событие передано диспетчеру,
+            ``False`` — если событие не удалось разобрать.
         """
         event_object = await process_update_webhook(
             event_json=event_json, bot=self.bot
         )
 
         if event_object is None:
-            msg = UNKNOWN_UPDATE_DISCLAIMER.format(
-                update_type=event_json.get("update_type")
-            )
-            logger_dp.warning(msg)
+            warn_unprocessable_event(event_json)
             return False
 
         if self.dp.use_create_task:

--- a/tests/test_unprocessable_updates.py
+++ b/tests/test_unprocessable_updates.py
@@ -1,0 +1,92 @@
+"""Тесты пропуска событий, которые не удалось разобрать.
+
+События с неизвестным типом, а также известным типом, но без
+обязательных полей, должны пропускаться без исключений; в лог
+при этом должно попадать соответствующее предупреждение.
+"""
+
+from unittest.mock import MagicMock
+
+from maxapi.methods.types.getted_updates import process_update_request
+
+
+async def test_message_created_without_message_is_skipped(caplog):
+    """message_created без тела сообщения сопровождается
+    предупреждением о неподдерживаемом сообщении на стороне MAX,
+    а не о неизвестном типе.
+    """
+    # Реальный кейс: голосовое сообщение боту приходит апдейтом
+    # message_created без поля message.
+    bot = MagicMock()
+    data = {
+        "updates": [
+            {
+                "timestamp": 1787423104297,
+                "user_locale": "ru",
+                "update_type": "message_created",
+            }
+        ],
+        "marker": 95412,
+    }
+
+    result = await process_update_request(data, bot)
+
+    assert result == []
+    assert "неизвестный тип" not in caplog.text
+    assert "неподдерживаемое сообщение" in caplog.text
+    assert "partner_support@max.ru" in caplog.text
+
+
+async def test_known_update_type_with_missing_fields_is_skipped(caplog):
+    """Известный тип события без обязательных полей пропускается
+    с предупреждением, направляющим в issue проекта, и JSON-payload
+    для приложения к issue.
+    """
+    bot = MagicMock()
+    # bot_started без обязательного поля user
+    data = {
+        "updates": [
+            {
+                "timestamp": 1787423104297,
+                "chat_id": 95412,
+                "update_type": "bot_started",
+            }
+        ],
+        "marker": 95412,
+    }
+
+    result = await process_update_request(data, bot)
+
+    assert result == []
+    assert "github.com/love-apples/maxapi/issues" in caplog.text
+    # Кейс message_created без тела сюда попадать не должен:
+    # у него отдельное сообщение про поддержку MAX
+    assert "partner_support@max.ru" not in caplog.text
+    assert "неизвестный тип" not in caplog.text
+    # JSON события должен попасть в лог для отправки в поддержку
+    assert '"chat_id": 95412' in caplog.text
+    assert '"update_type": "bot_started"' in caplog.text
+
+
+async def test_unknown_update_type_logged_as_unknown(caplog):
+    """Неизвестный тип события сопровождается предупреждением
+    UNKNOWN_UPDATE_DISCLAIMER и не ломает обработку остальных
+    событий.
+    """
+    bot = MagicMock()
+    data = {
+        "updates": [
+            {
+                "timestamp": 1787423104297,
+                "user_locale": "ru",
+                "update_type": "unknown_event_123",
+            }
+        ],
+        "marker": 95412,
+    }
+
+    result = await process_update_request(data, bot)
+
+    assert result == []
+    assert "неизвестный тип обновления" in caplog.text
+    assert "unknown_event_123" in caplog.text

--- a/tests/test_unprocessable_updates.py
+++ b/tests/test_unprocessable_updates.py
@@ -7,7 +7,20 @@
 
 from unittest.mock import MagicMock
 
-from maxapi.methods.types.getted_updates import process_update_request
+from maxapi.methods.types.getted_updates import (
+    _dump_event_json,
+    process_update_request,
+)
+
+
+def test_dump_event_json_fallback_on_unserializable_event():
+    """При циклических ссылках в событии json.dumps падает даже
+    с default=str — должен срабатывать fallback на str().
+    """
+    event: dict = {"update_type": "bot_started"}
+    event["self"] = event
+
+    assert _dump_event_json(event) == str(event)
 
 
 async def test_message_created_without_message_is_skipped(caplog):

--- a/tests/test_webhook/test_handle_webhook_route.py
+++ b/tests/test_webhook/test_handle_webhook_route.py
@@ -1,3 +1,5 @@
+import json
+
 import pytest
 
 pytest.importorskip("fastapi")
@@ -67,7 +69,8 @@ async def test_handle_webhook_unknown_update_logs_and_returns_ok(
     assert resp.json() == {"ok": True}
 
     expected_msg = UNKNOWN_UPDATE_DISCLAIMER.format(
-        update_type=payload.get("update_type")
+        update_type=payload.get("update_type"),
+        event_json=json.dumps(payload),
     )
     found = any(expected_msg in rec.getMessage() for rec in caplog.records)
     assert found


### PR DESCRIPTION
Ранее любое событие, не прошедшее валидацию, логировалось одинаково —
непонятно, куда обращаться пользователю.

Теперь новый хелпер `warn_unprocessable_event()` различает три случая
и подсказывает адресата:

- `message_created` без тела сообщения (например, голосовое сообщение
  боту) — известная проблема на стороне MAX →
  `UNSUPPORTED_MESSAGE_UPDATE_DISCLAIMER` → поддержка
  partner_support@max.ru;
- известный тип с некорректным содержимым →
  `MALFORMED_UPDATE_DISCLAIMER` → issue в репозитории проекта;
- неизвестный тип события → `UNKNOWN_UPDATE_DISCLAIMER` → обновить
  maxapi, при актуальной версии — issue.

Во все предупреждения добавлен однострочный JSON-payload события
(`_dump_event_json`, `ensure_ascii=False`, fallback на `str()`),
чтобы приложить его к обращению.

Предупреждение теперь пишется в одном месте — хелпере, — который
используется и в polling (`process_update_request`), и в вебхуке
(`_dispatch`). Логирование переведено на проектный `logger_dp`.

### Тесты и документация

- `test_unprocessable_updates.py`: покрыты
  все ветки классификации, включая попадание JSON-payload в лог;
- ожидания вебхук-тестов дополнены payload'ом;
- новые константы добавлены в `docs/types/updates/update.md`.