### PR TITLE
fix: управление жизненным циклом HTTP-сессии и её коннектора

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,11 @@ Async Python SDK + bot-фреймворк для мессенджера **MAX** 
   конфигурацию HTTP-соединения: `default_connection: DefaultConnectionProperties`.
 - `maxapi/client/default.py` — `DefaultConnectionProperties`: настройки aiohttp-клиента (таймауты,
   `max_retries`, `retry_on_statuses`, `retry_backoff_factor`).
-  Передаётся в `Bot(default_connection=DefaultConnectionProperties(...))`.
+  Передаётся в `Bot(default_connection=DefaultConnectionProperties(...))`. Остальные `**kwargs`
+  уходят в `ClientSession` через `client/ssl.py`. **Владение коннектором**: переданный
+  пользователем `connector` — чужой, `with_default_connector`/`connector_kwargs` проставляют ему
+  `connector_owner=False`, поэтому ни `close_session()`, ни временные сессии `upload_file*` его не
+  закрывают. Собственный дефолтный коннектор создаётся под каждую сессию с `connector_owner=True`.
 - `maxapi/methods/<verb>.py` — один класс на эндпоинт (`SendMessage`, `EditChat`, …). Конструктор
   валидирует/нормализует, `async def fetch()` собирает `params`/`json` и вызывает
   `super().request(method=HTTPMethod.X, path=ApiPath.Y, model=<PydanticResponse>, …)`. **Новый
@@ -23,8 +27,11 @@ Async Python SDK + bot-фреймворк для мессенджера **MAX** 
   `methods/send_message.py` как канонический пример (включая retry на `attachment.not.ready`).
 - `maxapi/connection/base.py` — `BaseConnection.request()`: единый HTTP-pipe c `aiohttp`,
   backoff-ретраями серверных 5xx и `ClientConnectionError`, парсингом ответа в pydantic-модель,
-  выбросом `MaxApiError`/`InvalidToken`/`MaxConnection`. `download_file` — потоковое скачивание
-  чанками `DOWNLOAD_CHUNK_SIZE=64KiB`.
+  выбросом `MaxApiError`/`InvalidToken`/`MaxConnection`. Разделяемую сессию `request()` **не
+  закрывает** — её жизненный цикл принадлежит `Bot` (`close_session`); на 401 тело ответа читается
+  в текст `InvalidToken`, уходит в `handle_raw_response` и ответ освобождается через
+  `resp.release()`. Сессия берётся внутри retry-цикла, а не до него. `download_file` — потоковое
+  скачивание чанками `DOWNLOAD_CHUNK_SIZE=64KiB`.
 - `maxapi/dispatcher.py` — `Dispatcher`/`Router` (Router = подкласс Dispatcher). Регистрация через
   `Event`-декораторы (`@dp.message_created(...)`, `@dp.bot_started()` …). `Dispatcher.handle()`
   строит **глобальный outer → роутерный outer → `_check_handler_match` → inner-цепочку (global

--- a/maxapi/client/ssl.py
+++ b/maxapi/client/ssl.py
@@ -39,6 +39,12 @@ def with_default_connector(kwargs: dict[str, Any]) -> dict[str, Any]:
     Собственный дефолтный коннектор создаётся под каждую сессию, и
     закрыть его сессия обязана: ``connector_owner=True``.
 
+    Явный ``connector=None`` — принятый в aiohttp способ попросить
+    коннектор по умолчанию — равносилен отсутствию ключа: подставляем
+    свой, с доверенным CA. Оставить ``None`` нельзя: aiohttp создал бы
+    коннектор сам, и при ``connector_owner=False`` его никто никогда
+    не закрыл бы.
+
     Args:
         kwargs: Пользовательские параметры ``ClientSession``.
 
@@ -48,7 +54,7 @@ def with_default_connector(kwargs: dict[str, Any]) -> dict[str, Any]:
     """
 
     session_kwargs = dict(kwargs)
-    if "connector" in session_kwargs:
+    if session_kwargs.get("connector") is not None:
         session_kwargs["connector_owner"] = False
     else:
         session_kwargs["connector"] = create_default_connector()
@@ -64,6 +70,9 @@ def connector_kwargs(kwargs: dict[str, Any]) -> dict[str, Any]:
     независимо от того, что передал пользователь. Созданный на месте
     дефолтный коннектор, наоборот, закрыть больше некому.
 
+    Явный ``connector=None`` равносилен отсутствию ключа — см.
+    :func:`with_default_connector`.
+
     Args:
         kwargs: Пользовательские параметры ``ClientSession``.
 
@@ -71,9 +80,10 @@ def connector_kwargs(kwargs: dict[str, Any]) -> dict[str, Any]:
         Словарь с ключами ``connector`` и ``connector_owner``.
     """
 
-    if "connector" in kwargs:
+    connector = kwargs.get("connector")
+    if connector is not None:
         return {
-            "connector": kwargs["connector"],
+            "connector": connector,
             "connector_owner": False,
         }
     return {"connector": create_default_connector(), "connector_owner": True}

--- a/maxapi/client/ssl.py
+++ b/maxapi/client/ssl.py
@@ -26,17 +26,54 @@ def create_default_connector() -> TCPConnector:
 
 
 def with_default_connector(kwargs: dict[str, Any]) -> dict[str, Any]:
-    """Добавить connector по умолчанию, если он не задан явно."""
+    """Добавить connector по умолчанию, если он не задан явно.
+
+    Пользовательский коннектор переиспользуется всеми сессиями бота и
+    переживает их пересоздание, поэтому владельцем остаётся
+    пользователь: ``connector_owner`` принудительно выставляется в
+    ``False``, и ``ClientSession.close()`` чужой коннектор не трогает.
+    Переданный пользователем ``connector_owner=True`` игнорируется —
+    он означал бы, что первый же ``close_session()`` закрывает
+    коннектор, который затем переиспользует следующая сессия.
+
+    Собственный дефолтный коннектор создаётся под каждую сессию, и
+    закрыть его сессия обязана: ``connector_owner=True``.
+
+    Args:
+        kwargs: Пользовательские параметры ``ClientSession``.
+
+    Returns:
+        Копия ``kwargs`` с проставленными ``connector`` и
+        ``connector_owner``.
+    """
 
     session_kwargs = dict(kwargs)
-    if "connector" not in session_kwargs:
+    if "connector" in session_kwargs:
+        session_kwargs["connector_owner"] = False
+    else:
         session_kwargs["connector"] = create_default_connector()
+        session_kwargs["connector_owner"] = True
     return session_kwargs
 
 
 def connector_kwargs(kwargs: dict[str, Any]) -> dict[str, Any]:
-    """Вернуть только connector для временной aiohttp-сессии."""
+    """Вернуть connector и его владельца для временной aiohttp-сессии.
+
+    Временная сессия живёт один вызов, поэтому пользовательский
+    коннектор она не закрывает никогда — ``connector_owner=False``
+    независимо от того, что передал пользователь. Созданный на месте
+    дефолтный коннектор, наоборот, закрыть больше некому.
+
+    Args:
+        kwargs: Пользовательские параметры ``ClientSession``.
+
+    Returns:
+        Словарь с ключами ``connector`` и ``connector_owner``.
+    """
 
     if "connector" in kwargs:
-        return {"connector": kwargs["connector"]}
-    return {"connector": create_default_connector()}
+        return {
+            "connector": kwargs["connector"],
+            "connector_owner": False,
+        }
+    return {"connector": create_default_connector(), "connector_owner": True}

--- a/maxapi/connection/base.py
+++ b/maxapi/connection/base.py
@@ -313,8 +313,13 @@ class BaseConnection(BotMixin):
             )
 
             if resp.status == 401:
-                raw = await _read_error_payload(resp)
-                resp.release()
+                # finally, а не последовательность: отмена во время
+                # чтения тела бросает CancelledError мимо except
+                # Exception, и ответ остался бы неосвобождённым
+                try:
+                    raw = await _read_error_payload(resp)
+                finally:
+                    resp.release()
                 _schedule_raw_response(bot, raw)
                 raise InvalidToken(_invalid_token_message(raw))
 

--- a/maxapi/connection/base.py
+++ b/maxapi/connection/base.py
@@ -43,6 +43,10 @@ if TYPE_CHECKING:
 
 DOWNLOAD_CHUNK_SIZE = 65536
 
+#: Максимальная длина тела ответа в тексте исключения. Полное тело
+#: уходит подписчикам ``RAW_API_RESPONSE`` без усечения.
+ERROR_DETAILS_LIMIT = 512
+
 
 class _RetryableServerError(Exception):
     """Внутреннее исключение для retry при серверных ошибках."""
@@ -90,6 +94,101 @@ def _on_backoff(details: Details) -> None:
             exc,
             tries,
             wait,
+        )
+
+
+async def _session_request(
+    session: ClientSession, *args: Any, **kwargs: Any
+) -> ClientResponse:
+    """Выполнить запрос, переведя «Session is closed» в retryable-ошибку.
+
+    ``aiohttp`` бросает голый ``RuntimeError``, если сессию закрыли
+    между её получением и стартом запроса. Ни одного байта при этом
+    не отправлено, поэтому попытку безопасно повторить: на следующей
+    итерации ``ensure_session()`` выдаст живую сессию.
+
+    Args:
+        session: Сессия, через которую выполняется запрос.
+        *args: Позиционные аргументы ``ClientSession.request``.
+        **kwargs: Именованные аргументы ``ClientSession.request``.
+
+    Returns:
+        Ответ сервера.
+
+    Raises:
+        ClientConnectionError: Если сессия была закрыта до старта.
+    """
+
+    try:
+        return await session.request(*args, **kwargs)
+    except RuntimeError as e:
+        if session.closed:
+            raise ClientConnectionError(
+                "Сессия была закрыта до отправки запроса"
+            ) from e
+        raise
+
+
+async def _read_error_payload(resp: ClientResponse) -> dict[str, Any]:
+    """Прочитать тело ошибочного ответа, не падая на не-JSON.
+
+    Args:
+        resp: Ответ, тело которого нужно прочитать.
+
+    Returns:
+        Разобранный JSON-объект, ``{"error": <тело>}`` для остальных
+        форматов или пустой словарь, если тело прочитать не удалось.
+    """
+
+    try:
+        payload = await resp.json(content_type=None)
+    except Exception:
+        try:
+            text = await resp.text()
+        except Exception:
+            return {}
+        return {"error": text} if text else {}
+
+    if isinstance(payload, dict):
+        return payload
+    return {"error": payload} if payload is not None else {}
+
+
+def _invalid_token_message(raw: dict[str, Any]) -> str:
+    """Собрать текст ``InvalidToken`` с усечённой диагностикой.
+
+    Args:
+        raw: Тело ответа 401.
+
+    Returns:
+        Сообщение об ошибке; тело обрезается до
+        ``ERROR_DETAILS_LIMIT`` символов, чтобы многомегабайтная
+        страница от прокси не утекла в логи целиком.
+    """
+
+    message = "Неверный токен!"
+    if not raw:
+        return message
+
+    details = str(raw)
+    if len(details) > ERROR_DETAILS_LIMIT:
+        details = f"{details[:ERROR_DETAILS_LIMIT]}…"
+    return f"{message} Ответ API: {details}"
+
+
+def _schedule_raw_response(bot: Bot, raw: Any) -> None:
+    """Уведомить подписчиков ``RAW_API_RESPONSE``, не блокируя запрос.
+
+    Args:
+        bot: Бот, чей диспетчер получит событие.
+        raw: Сырой ответ API.
+    """
+
+    if bot.dispatcher:
+        asyncio.create_task(
+            bot.dispatcher.handle_raw_response(
+                UpdateType.RAW_API_RESPONSE, raw
+            )
         )
 
 
@@ -182,15 +281,18 @@ class BaseConnection(BotMixin):
         )
         async def _do_request() -> Any:
             session = await bot.ensure_session()
-            resp = await session.request(
+            resp = await _session_request(
+                session,
                 method=method.value,
                 url=url,
                 **kwargs,
             )
 
             if resp.status == 401:
-                await session.close()
-                raise InvalidToken("Неверный токен!")
+                raw = await _read_error_payload(resp)
+                resp.release()
+                _schedule_raw_response(bot, raw)
+                raise InvalidToken(_invalid_token_message(raw))
 
             if resp.status in retry_statuses:
                 await resp.read()
@@ -207,22 +309,12 @@ class BaseConnection(BotMixin):
 
         if not response.ok:
             raw = await response.json()
-            if bot.dispatcher:
-                asyncio.create_task(
-                    bot.dispatcher.handle_raw_response(
-                        UpdateType.RAW_API_RESPONSE, raw
-                    )
-                )
+            _schedule_raw_response(bot, raw)
             raise MaxApiError(code=response.status, raw=raw)
 
         raw = await response.json()
 
-        if bot.dispatcher:
-            asyncio.create_task(
-                bot.dispatcher.handle_raw_response(
-                    UpdateType.RAW_API_RESPONSE, raw
-                )
-            )
+        _schedule_raw_response(bot, raw)
 
         if is_return_raw:
             return raw
@@ -330,7 +422,6 @@ class BaseConnection(BotMixin):
 
     async def _fetch_response(self, url: str) -> ClientResponse:
         bot = self._ensure_bot()
-        session = await bot.ensure_session()
         conn = bot.default_connection
 
         @backoff.on_exception(
@@ -341,7 +432,8 @@ class BaseConnection(BotMixin):
             on_backoff=_on_backoff,
         )
         async def _do_request() -> Any:
-            resp = await session.request("GET", url)
+            session = await bot.ensure_session()
+            resp = await _session_request(session, "GET", url)
             if resp.status in conn.retry_on_statuses:
                 await resp.read()
                 raise _RetryableServerError(resp.status)

--- a/maxapi/connection/base.py
+++ b/maxapi/connection/base.py
@@ -154,6 +154,33 @@ async def _read_error_payload(resp: ClientResponse) -> dict[str, Any]:
     return {"error": payload} if payload is not None else {}
 
 
+def _error_details(raw: dict[str, Any]) -> str:
+    """Отрендерить тело ошибки для текста исключения.
+
+    Не-JSON тело ``_read_error_payload`` кладёт одной строкой под ключ
+    ``error``. Её режем напрямую: ``str(raw)`` на многомегабайтной
+    странице от прокси заново материализовал бы её целиком (да ещё и
+    с экранированием) только ради того, чтобы отбросить всё после
+    ``ERROR_DETAILS_LIMIT``.
+
+    Args:
+        raw: Тело ответа.
+
+    Returns:
+        Диагностика, обрезанная до ``ERROR_DETAILS_LIMIT`` символов.
+    """
+
+    text = raw.get("error")
+    if len(raw) == 1 and isinstance(text, str):
+        details = text
+    else:
+        details = str(raw)
+
+    if len(details) > ERROR_DETAILS_LIMIT:
+        return f"{details[:ERROR_DETAILS_LIMIT]}…"
+    return details
+
+
 def _invalid_token_message(raw: dict[str, Any]) -> str:
     """Собрать текст ``InvalidToken`` с усечённой диагностикой.
 
@@ -170,10 +197,7 @@ def _invalid_token_message(raw: dict[str, Any]) -> str:
     if not raw:
         return message
 
-    details = str(raw)
-    if len(details) > ERROR_DETAILS_LIMIT:
-        details = f"{details[:ERROR_DETAILS_LIMIT]}…"
-    return f"{message} Ответ API: {details}"
+    return f"{message} Ответ API: {_error_details(raw)}"
 
 
 def _schedule_raw_response(bot: Bot, raw: Any) -> None:

--- a/tests/test_client_ssl.py
+++ b/tests/test_client_ssl.py
@@ -1,23 +1,84 @@
 """Тесты SSL-настроек aiohttp-клиента."""
 
+from aiohttp import TCPConnector
 from maxapi.client.ssl import connector_kwargs, with_default_connector
 
 
 def test_with_default_connector_preserves_custom_connector():
-    """Пользовательский connector не заменяется."""
+    """Пользовательский connector не заменяется и не переходит в владение."""
     connector = object()
 
     result = with_default_connector({"connector": connector})
 
-    assert result == {"connector": connector}
+    assert result["connector"] is connector
+    assert result["connector_owner"] is False
+
+
+def test_with_default_connector_ignores_explicit_owner():
+    """Явный connector_owner=True не даёт сессии закрыть чужой connector.
+
+    Сессия бота пересоздаётся поверх того же коннектора, поэтому
+    передача владения ей означала бы смерть коннектора после первого
+    close_session().
+    """
+    connector = object()
+
+    result = with_default_connector(
+        {"connector": connector, "connector_owner": True}
+    )
+
+    assert result["connector"] is connector
+    assert result["connector_owner"] is False
+
+
+def test_connector_kwargs_ignores_explicit_owner():
+    """Временная сессия не забирает владение даже по явной просьбе."""
+    connector = object()
+
+    result = connector_kwargs(
+        {"connector": connector, "connector_owner": True}
+    )
+
+    assert result == {"connector": connector, "connector_owner": False}
+
+
+async def test_with_default_connector_owns_created_connector():
+    """Собственный дефолтный connector закрывается сессией."""
+    result = with_default_connector({})
+
+    assert isinstance(result["connector"], TCPConnector)
+    assert result["connector_owner"] is True
+
+    await result["connector"].close()
+
+
+async def test_with_default_connector_does_not_mutate_source():
+    """Исходный словарь kwargs не изменяется."""
+    kwargs: dict = {}
+
+    result = with_default_connector(kwargs)
+
+    assert kwargs == {}
+
+    await result["connector"].close()
 
 
 def test_connector_kwargs_does_not_leak_session_kwargs():
-    """Для временной сессии возвращается только connector."""
+    """Для временной сессии возвращается только connector и владелец."""
     connector = object()
 
     result = connector_kwargs(
         {"connector": connector, "raise_for_status": True}
     )
 
-    assert result == {"connector": connector}
+    assert result == {"connector": connector, "connector_owner": False}
+
+
+async def test_connector_kwargs_owns_created_connector():
+    """Временная сессия закрывает созданный ею дефолтный connector."""
+    result = connector_kwargs({})
+
+    assert isinstance(result["connector"], TCPConnector)
+    assert result["connector_owner"] is True
+
+    await result["connector"].close()

--- a/tests/test_client_ssl.py
+++ b/tests/test_client_ssl.py
@@ -63,6 +63,30 @@ async def test_with_default_connector_does_not_mutate_source():
     await result["connector"].close()
 
 
+async def test_with_default_connector_treats_none_as_absent():
+    """`connector=None` не оставляется как есть — иначе коннектор течёт.
+
+    aiohttp на `None` создаёт коннектор сам, и при
+    `connector_owner=False` закрыть его было бы уже некому.
+    """
+    result = with_default_connector({"connector": None})
+
+    assert isinstance(result["connector"], TCPConnector)
+    assert result["connector_owner"] is True
+
+    await result["connector"].close()
+
+
+async def test_connector_kwargs_treats_none_as_absent():
+    """`connector=None` для временной сессии — тоже свой коннектор."""
+    result = connector_kwargs({"connector": None})
+
+    assert isinstance(result["connector"], TCPConnector)
+    assert result["connector_owner"] is True
+
+    await result["connector"].close()
+
+
 def test_connector_kwargs_does_not_leak_session_kwargs():
     """Для временной сессии возвращается только connector и владелец."""
     connector = object()

--- a/tests/test_session_lifecycle.py
+++ b/tests/test_session_lifecycle.py
@@ -521,6 +521,53 @@ class TestInvalidTokenMessageIsBounded:
         message = str(exc_info.value)
         assert len(message) < 1000
         assert message.endswith("…")
+        # Строка режется напрямую, без материализации str(raw)
+        assert message.startswith("Неверный токен! Ответ API: xxx")
+        assert "{'error'" not in message
+
+    async def test_dict_body_keeps_dict_rendering(self, mock_bot_token):
+        """Разобранный JSON-объект по-прежнему рендерится целиком."""
+        bot = Bot(token=mock_bot_token)
+        session = MagicMock()
+        session.closed = False
+        raw = {"code": "verify.token", "message": "invalid access_token"}
+        session.request = AsyncMock(return_value=_make_401(json_data=raw))
+        bot.session = session
+
+        conn = BaseConnection()
+        conn.bot = bot
+
+        with pytest.raises(InvalidToken) as exc_info:
+            await conn.request(
+                method=HTTPMethod.GET,
+                path="/test",
+                is_return_raw=True,
+            )
+
+        assert str(raw) in str(exc_info.value)
+
+    async def test_huge_dict_body_is_truncated(self, mock_bot_token):
+        """Многокилобайтный JSON-объект тоже обрезается."""
+        bot = Bot(token=mock_bot_token)
+        session = MagicMock()
+        session.closed = False
+        raw = {"code": "verify.token", "message": "y" * 100_000}
+        session.request = AsyncMock(return_value=_make_401(json_data=raw))
+        bot.session = session
+
+        conn = BaseConnection()
+        conn.bot = bot
+
+        with pytest.raises(InvalidToken) as exc_info:
+            await conn.request(
+                method=HTTPMethod.GET,
+                path="/test",
+                is_return_raw=True,
+            )
+
+        message = str(exc_info.value)
+        assert len(message) < 1000
+        assert message.endswith("…")
 
     async def test_full_body_still_reaches_subscribers(self, mock_bot_token):
         """Подписчики RAW_API_RESPONSE получают тело без усечения."""

--- a/tests/test_session_lifecycle.py
+++ b/tests/test_session_lifecycle.py
@@ -1,0 +1,498 @@
+"""Тесты жизненного цикла HTTP-сессии и её коннектора.
+
+Регрессия на issue #197: пользовательский коннектор не должен
+закрываться сессиями бота, а ответ 401 — рвать разделяемую сессию
+из-под параллельных запросов.
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from aiohttp import ClientSession, TCPConnector
+from maxapi import Bot
+from maxapi.client.default import DefaultConnectionProperties
+from maxapi.connection.base import BaseConnection
+from maxapi.enums.http_method import HTTPMethod
+from maxapi.enums.update import UpdateType
+from maxapi.enums.upload_type import UploadType
+from maxapi.exceptions.download_file import DownloadFileError
+from maxapi.exceptions.max import InvalidToken, MaxConnection
+
+
+def _make_401(*, json_data=None, text=None):
+    """Мок ответа 401 с настраиваемым телом."""
+    resp = MagicMock()
+    resp.status = 401
+    resp.ok = False
+    resp.release = MagicMock()
+    if json_data is not None:
+        resp.json = AsyncMock(return_value=json_data)
+    else:
+        resp.json = AsyncMock(side_effect=ValueError("not json"))
+    resp.text = AsyncMock(return_value=text if text is not None else "")
+    return resp
+
+
+async def _drain_tasks() -> None:
+    """Отдаёт управление циклу, чтобы отработали созданные задачи."""
+    await asyncio.sleep(0)
+
+
+class TestCustomConnectorOwnership:
+    """Пользовательский коннектор переживает закрытие сессий."""
+
+    async def test_close_session_keeps_custom_connector_alive(
+        self, mock_bot_token
+    ):
+        """close_session() не закрывает чужой коннектор."""
+        connector = TCPConnector()
+        bot = Bot(
+            token=mock_bot_token,
+            default_connection=DefaultConnectionProperties(
+                connector=connector
+            ),
+        )
+
+        try:
+            first = await bot.ensure_session()
+            await bot.close_session()
+
+            assert first.closed is True
+            assert connector.closed is False
+
+            second = await bot.ensure_session()
+
+            assert second is not first
+            assert second.closed is False
+
+            await bot.close_session()
+            assert connector.closed is False
+        finally:
+            await connector.close()
+
+    async def test_temp_upload_session_keeps_custom_connector_alive(
+        self, mock_bot_token, tmp_path
+    ):
+        """Временная сессия upload_file не закрывает чужой коннектор."""
+        connector = TCPConnector()
+        bot = Bot(
+            token=mock_bot_token,
+            default_connection=DefaultConnectionProperties(
+                connector=connector
+            ),
+        )
+        bot.session = None
+
+        conn = BaseConnection()
+        conn.bot = bot
+
+        test_file = tmp_path / "photo.png"
+        test_file.write_bytes(b"fake-png-data")
+
+        created: list[ClientSession] = []
+        original_post = ClientSession.post
+
+        def fake_post(self, *args, **kwargs):
+            created.append(self)
+            response = AsyncMock()
+            response.text = AsyncMock(return_value="ok")
+            cm = AsyncMock()
+            cm.__aenter__.return_value = response
+            cm.__aexit__.return_value = False
+            return cm
+
+        try:
+            ClientSession.post = fake_post  # type: ignore[method-assign]
+            result = await conn.upload_file(
+                url="https://upload.example.com",
+                path=str(test_file),
+                type=UploadType.IMAGE,
+            )
+        finally:
+            ClientSession.post = original_post  # type: ignore[method-assign]
+
+        assert result == "ok"
+        assert len(created) == 1
+        assert created[0].closed is True
+        assert connector.closed is False
+
+        await connector.close()
+
+    async def test_default_connector_is_closed_with_session(
+        self, mock_bot_token
+    ):
+        """Собственный дефолтный коннектор закрывается вместе с сессией."""
+        bot = Bot(token=mock_bot_token)
+
+        session = await bot.ensure_session()
+        connector = session.connector
+        assert connector is not None
+
+        await bot.close_session()
+
+        assert connector.closed is True
+
+
+class TestUnauthorizedDoesNotCloseSession:
+    """401 не трогает разделяемую сессию."""
+
+    @pytest.fixture
+    def bot_with_mock_session(self, mock_bot_token):
+        """Бот с мок-сессией, отслеживающей close()."""
+        bot = Bot(token=mock_bot_token)
+        session = MagicMock()
+        session.closed = False
+        session.close = AsyncMock()
+        bot.session = session
+        return bot
+
+    async def test_session_not_closed_on_401(self, bot_with_mock_session):
+        """Сессия остаётся живой — параллельные запросы не рвутся."""
+        bot_with_mock_session.session.request = AsyncMock(
+            return_value=_make_401()
+        )
+
+        conn = BaseConnection()
+        conn.bot = bot_with_mock_session
+
+        with pytest.raises(InvalidToken):
+            await conn.request(
+                method=HTTPMethod.GET,
+                path="/test",
+                is_return_raw=True,
+            )
+
+        bot_with_mock_session.session.close.assert_not_called()
+        assert bot_with_mock_session.session.closed is False
+
+    async def test_401_body_lands_in_exception(self, bot_with_mock_session):
+        """Тело ответа 401 попадает в текст InvalidToken."""
+        raw = {"code": "verify.token", "message": "invalid access_token"}
+        response = _make_401(json_data=raw)
+        bot_with_mock_session.session.request = AsyncMock(
+            return_value=response
+        )
+
+        conn = BaseConnection()
+        conn.bot = bot_with_mock_session
+
+        with pytest.raises(InvalidToken) as exc_info:
+            await conn.request(
+                method=HTTPMethod.GET,
+                path="/test",
+                is_return_raw=True,
+            )
+
+        message = str(exc_info.value)
+        assert "Неверный токен!" in message
+        assert "invalid access_token" in message
+        response.release.assert_called_once()
+
+    async def test_401_non_json_body_does_not_break(
+        self, bot_with_mock_session
+    ):
+        """Не-JSON тело 401 не подменяет InvalidToken другой ошибкой."""
+        response = _make_401(text="<html>403 Forbidden</html>")
+        bot_with_mock_session.session.request = AsyncMock(
+            return_value=response
+        )
+
+        conn = BaseConnection()
+        conn.bot = bot_with_mock_session
+
+        with pytest.raises(InvalidToken) as exc_info:
+            await conn.request(
+                method=HTTPMethod.GET,
+                path="/test",
+                is_return_raw=True,
+            )
+
+        assert "403 Forbidden" in str(exc_info.value)
+
+    async def test_401_unreadable_body_keeps_plain_message(
+        self, bot_with_mock_session
+    ):
+        """Нечитаемое тело 401 оставляет сообщение без диагностики."""
+        response = _make_401()
+        response.text = AsyncMock(side_effect=OSError("boom"))
+        bot_with_mock_session.session.request = AsyncMock(
+            return_value=response
+        )
+
+        conn = BaseConnection()
+        conn.bot = bot_with_mock_session
+
+        with pytest.raises(InvalidToken) as exc_info:
+            await conn.request(
+                method=HTTPMethod.GET,
+                path="/test",
+                is_return_raw=True,
+            )
+
+        assert str(exc_info.value) == "Неверный токен!"
+
+    async def test_401_notifies_raw_response_subscribers(
+        self, bot_with_mock_session
+    ):
+        """Для 401 вызывается handle_raw_response, как и для прочих ошибок."""
+        raw = {"code": "verify.token", "message": "invalid access_token"}
+        bot_with_mock_session.session.request = AsyncMock(
+            return_value=_make_401(json_data=raw)
+        )
+
+        dispatcher = MagicMock()
+        dispatcher.handle_raw_response = AsyncMock()
+        bot_with_mock_session.dispatcher = dispatcher
+
+        conn = BaseConnection()
+        conn.bot = bot_with_mock_session
+
+        with pytest.raises(InvalidToken):
+            await conn.request(
+                method=HTTPMethod.GET,
+                path="/test",
+                is_return_raw=True,
+            )
+
+        # handle_raw_response планируется задачей — даём ей отработать
+        await _drain_tasks()
+
+        dispatcher.handle_raw_response.assert_awaited_once_with(
+            UpdateType.RAW_API_RESPONSE, raw
+        )
+
+
+class TestFetchResponseSessionResolution:
+    """_fetch_response берёт сессию внутри retry-цикла."""
+
+    async def test_session_resolved_per_attempt(self, mock_bot_token):
+        """Сессия запрашивается на каждой попытке, а не один раз до цикла."""
+        bot = Bot(
+            token=mock_bot_token,
+            default_connection=DefaultConnectionProperties(
+                max_retries=2,
+                retry_backoff_factor=0.001,
+            ),
+        )
+
+        ok = MagicMock()
+        ok.status = 200
+        ok.ok = True
+
+        retryable = MagicMock()
+        retryable.status = 503
+        retryable.ok = False
+        retryable.read = AsyncMock()
+
+        sessions = []
+
+        def make_session(responses):
+            session = MagicMock()
+            session.closed = False
+            session.request = AsyncMock(side_effect=responses)
+            return session
+
+        first = make_session([retryable])
+        second = make_session([ok])
+        sessions.extend([first, second])
+
+        calls = {"n": 0}
+
+        async def ensure_session():
+            session = sessions[min(calls["n"], len(sessions) - 1)]
+            calls["n"] += 1
+            return session
+
+        bot.ensure_session = ensure_session  # type: ignore[method-assign]
+
+        conn = BaseConnection()
+        conn.bot = bot
+
+        response = await conn._fetch_response("https://example.com/file")
+
+        assert response is ok
+        assert calls["n"] == 2
+        first.request.assert_awaited_once()
+        second.request.assert_awaited_once()
+
+
+class TestClosedSessionIsRetryable:
+    """Закрытая на лету сессия не выпускает голый RuntimeError."""
+
+    @staticmethod
+    def _closed_session():
+        """Сессия, отвечающая RuntimeError, как закрытая aiohttp-сессия."""
+        session = MagicMock()
+        session.closed = True
+        session.request = AsyncMock(
+            side_effect=RuntimeError("Session is closed")
+        )
+        return session
+
+    @staticmethod
+    def _pin_sessions(bot, sessions):
+        """Заставить ensure_session() отдавать заданные сессии по порядку.
+
+        Подменяем сам ensure_session: закрытую сессию он бы заменил
+        новой и увёл тест в реальную сеть.
+        """
+        calls = {"n": 0}
+
+        async def ensure_session():
+            session = sessions[min(calls["n"], len(sessions) - 1)]
+            calls["n"] += 1
+            return session
+
+        bot.ensure_session = ensure_session
+        return calls
+
+    async def test_request_wraps_closed_session(self, mock_bot_token):
+        """request() отдаёт MaxConnection, а не RuntimeError."""
+        bot = Bot(
+            token=mock_bot_token,
+            default_connection=DefaultConnectionProperties(
+                max_retries=1,
+                retry_backoff_factor=0.001,
+            ),
+        )
+        closed = self._closed_session()
+        calls = self._pin_sessions(bot, [closed])
+
+        conn = BaseConnection()
+        conn.bot = bot
+
+        with pytest.raises(MaxConnection):
+            await conn.request(
+                method=HTTPMethod.GET,
+                path="/test",
+                is_return_raw=True,
+            )
+
+        # max_retries=1 — исходная попытка плюс один ретрай
+        assert calls["n"] == 2
+
+    async def test_request_retries_on_reopened_session(self, mock_bot_token):
+        """Следующая попытка идёт уже через свежую сессию."""
+        bot = Bot(
+            token=mock_bot_token,
+            default_connection=DefaultConnectionProperties(
+                max_retries=1,
+                retry_backoff_factor=0.001,
+            ),
+        )
+
+        ok = MagicMock()
+        ok.status = 200
+        ok.ok = True
+        ok.json = AsyncMock(return_value={"success": True})
+
+        alive = MagicMock()
+        alive.closed = False
+        alive.request = AsyncMock(return_value=ok)
+
+        calls = self._pin_sessions(bot, [self._closed_session(), alive])
+
+        conn = BaseConnection()
+        conn.bot = bot
+
+        result = await conn.request(
+            method=HTTPMethod.GET,
+            path="/test",
+            is_return_raw=True,
+        )
+
+        assert result == {"success": True}
+        assert calls["n"] == 2
+
+    async def test_download_wraps_closed_session(self, mock_bot_token):
+        """_fetch_response() отдаёт DownloadFileError, а не RuntimeError."""
+        bot = Bot(
+            token=mock_bot_token,
+            default_connection=DefaultConnectionProperties(
+                max_retries=0,
+            ),
+        )
+        self._pin_sessions(bot, [self._closed_session()])
+
+        conn = BaseConnection()
+        conn.bot = bot
+
+        with pytest.raises(DownloadFileError):
+            await conn._fetch_response("https://example.com/file")
+
+    async def test_runtime_error_on_live_session_propagates(
+        self, mock_bot_token
+    ):
+        """RuntimeError живой сессии не маскируется под сетевую ошибку."""
+        bot = Bot(token=mock_bot_token)
+        session = MagicMock()
+        session.closed = False
+        session.request = AsyncMock(side_effect=RuntimeError("что-то ещё"))
+        bot.session = session
+
+        conn = BaseConnection()
+        conn.bot = bot
+
+        with pytest.raises(RuntimeError, match="что-то ещё"):
+            await conn.request(
+                method=HTTPMethod.GET,
+                path="/test",
+                is_return_raw=True,
+            )
+
+
+class TestInvalidTokenMessageIsBounded:
+    """Тело 401 не утекает в лог целиком."""
+
+    async def test_huge_body_is_truncated(self, mock_bot_token):
+        """Многокилобайтная страница обрезается в тексте исключения."""
+        bot = Bot(token=mock_bot_token)
+        session = MagicMock()
+        session.closed = False
+        huge = "x" * 100_000
+        session.request = AsyncMock(return_value=_make_401(text=huge))
+        bot.session = session
+
+        conn = BaseConnection()
+        conn.bot = bot
+
+        with pytest.raises(InvalidToken) as exc_info:
+            await conn.request(
+                method=HTTPMethod.GET,
+                path="/test",
+                is_return_raw=True,
+            )
+
+        message = str(exc_info.value)
+        assert len(message) < 1000
+        assert message.endswith("…")
+
+    async def test_full_body_still_reaches_subscribers(self, mock_bot_token):
+        """Подписчики RAW_API_RESPONSE получают тело без усечения."""
+        bot = Bot(token=mock_bot_token)
+        session = MagicMock()
+        session.closed = False
+        huge = "x" * 100_000
+        session.request = AsyncMock(return_value=_make_401(text=huge))
+        bot.session = session
+
+        dispatcher = MagicMock()
+        dispatcher.handle_raw_response = AsyncMock()
+        bot.dispatcher = dispatcher
+
+        conn = BaseConnection()
+        conn.bot = bot
+
+        with pytest.raises(InvalidToken):
+            await conn.request(
+                method=HTTPMethod.GET,
+                path="/test",
+                is_return_raw=True,
+            )
+
+        await _drain_tasks()
+
+        dispatcher.handle_raw_response.assert_awaited_once_with(
+            UpdateType.RAW_API_RESPONSE, {"error": huge}
+        )

--- a/tests/test_session_lifecycle.py
+++ b/tests/test_session_lifecycle.py
@@ -286,6 +286,32 @@ class TestUnauthorizedDoesNotCloseSession:
 
         assert str(exc_info.value) == "Неверный токен!"
 
+    async def test_401_releases_response_on_cancellation(
+        self, bot_with_mock_session
+    ):
+        """Отмена во время чтения тела 401 всё равно освобождает ответ.
+
+        CancelledError наследуется от BaseException и проходит мимо
+        `except Exception` внутри `_read_error_payload`.
+        """
+        response = _make_401()
+        response.text = AsyncMock(side_effect=asyncio.CancelledError())
+        bot_with_mock_session.session.request = AsyncMock(
+            return_value=response
+        )
+
+        conn = BaseConnection()
+        conn.bot = bot_with_mock_session
+
+        with pytest.raises(asyncio.CancelledError):
+            await conn.request(
+                method=HTTPMethod.GET,
+                path="/test",
+                is_return_raw=True,
+            )
+
+        response.release.assert_called_once()
+
     async def test_401_notifies_raw_response_subscribers(
         self, bot_with_mock_session
     ):

--- a/tests/test_session_lifecycle.py
+++ b/tests/test_session_lifecycle.py
@@ -232,6 +232,60 @@ class TestUnauthorizedDoesNotCloseSession:
 
         assert str(exc_info.value) == "Неверный токен!"
 
+    async def test_401_scalar_json_body_is_wrapped(
+        self, bot_with_mock_session
+    ):
+        """Не-объектный JSON в теле 401 оборачивается в {"error": ...}."""
+        response = _make_401(json_data="access_token is revoked")
+        bot_with_mock_session.session.request = AsyncMock(
+            return_value=response
+        )
+
+        dispatcher = MagicMock()
+        dispatcher.handle_raw_response = AsyncMock()
+        bot_with_mock_session.dispatcher = dispatcher
+
+        conn = BaseConnection()
+        conn.bot = bot_with_mock_session
+
+        with pytest.raises(InvalidToken) as exc_info:
+            await conn.request(
+                method=HTTPMethod.GET,
+                path="/test",
+                is_return_raw=True,
+            )
+
+        assert "access_token is revoked" in str(exc_info.value)
+
+        await _drain_tasks()
+
+        dispatcher.handle_raw_response.assert_awaited_once_with(
+            UpdateType.RAW_API_RESPONSE,
+            {"error": "access_token is revoked"},
+        )
+
+    async def test_401_json_null_body_keeps_plain_message(
+        self, bot_with_mock_session
+    ):
+        """Тело `null` не превращается в {"error": None}."""
+        response = _make_401(json_data=None)
+        response.json = AsyncMock(return_value=None)
+        bot_with_mock_session.session.request = AsyncMock(
+            return_value=response
+        )
+
+        conn = BaseConnection()
+        conn.bot = bot_with_mock_session
+
+        with pytest.raises(InvalidToken) as exc_info:
+            await conn.request(
+                method=HTTPMethod.GET,
+                path="/test",
+                is_return_raw=True,
+            )
+
+        assert str(exc_info.value) == "Неверный токен!"
+
     async def test_401_notifies_raw_response_subscribers(
         self, bot_with_mock_session
     ):


### PR DESCRIPTION
Closes #197

Два независимых дефекта в работе с `aiohttp.ClientSession`/`TCPConnector`. По отдельности каждый приводит к невосстановимому `RuntimeError: Session is closed`, вместе — усиливают друг друга.

## 1. Пользовательский `connector` уничтожался при пересоздании сессии

`with_default_connector` клал переданный пользователем `connector` в **каждую** новую `ClientSession`, а та создавалась с дефолтным `connector_owner=True`. Первый же `close_session()` закрывал чужой коннектор — навсегда, потому что нового библиотека не создаёт. То же делали временные сессии в `upload_file` / `upload_file_buffer`.

Владение теперь выражено явно и однозначно:

| коннектор | `connector_owner` | кто закрывает |
|---|---|---|
| пользовательский | `False` | пользователь |
| дефолтный (создаётся под каждую сессию) | `True` | сессия |

Явный `connector_owner=True` рядом с пользовательским коннектором игнорируется намеренно: коннектор переиспользуется всеми пересоздаваемыми сессиями бота, поэтому передача владения любой из них означает смерть коннектора после первого `close_session()` — корректного прочтения у этого флага здесь нет. Худший исход нового поведения — незакрытый коннектор с громким варнингом aiohttp; худший исход старого — молча и необратимо мёртвый бот.

## 2. Ответ 401 закрывал разделяемую сессию из-под параллельных запросов

```python
if resp.status == 401:
    await session.close()          # ← закрыта ОБЩАЯ сессия бота
    raise InvalidToken("Неверный токен!")
```

В polling с `use_create_task=True` и в webhook одновременно летит несколько запросов; после `session.close()` все параллельные in-flight падали с `RuntimeError: Session is closed` вместо своего результата. А в паре с дефектом №1 один ответ 401 отправлял бота в кому.

Жизненный цикл сессии принадлежит владельцу (`Bot.close_session`), поэтому `request()` её больше не закрывает. Вместо этого:

- читает тело ответа — устойчиво к не-JSON и к нечитаемому телу;
- кладёт диагностику в текст `InvalidToken` (усечённую до 512 символов, чтобы многомегабайтная заглушка от прокси не уехала в лог целиком — подписчикам тело уходит без усечения);
- вызывает `handle_raw_response`, как для всех прочих ошибок;
- освобождает ответ через `resp.release()`.

## Дополнительно

- `_fetch_response()` получает сессию **внутри** retry-цикла, а не до него.
- `RuntimeError("Session is closed")` переводится в `ClientConnectionError`. aiohttp бросает его в самом начале `_request()`, до отправки первого байта, — значит повтор безопасен, `ensure_session()` на следующей попытке отдаёт живую сессию, а при исчерпании ретраев наружу уходит `MaxConnection` / `DownloadFileError` согласно контракту `Raises:`. `RuntimeError` живой сессии по-прежнему пробрасывается нетронутым — маскировать чужие баги под сетевые не нужно.
- Три копии планирования `handle_raw_response` схлопнуты в `_schedule_raw_response()`.

## Тесты

Новый `tests/test_session_lifecycle.py` — 15 тестов: цикл `ensure → close → ensure` с пользовательским коннектором, временная upload-сессия, свой дефолтный коннектор (закрывается, как и должен), 401 без закрытия сессии, тело 401 в исключении, не-JSON и нечитаемое тело, уведомление подписчиков, резолв сессии на каждой попытке, обёртка закрытой сессии в `MaxConnection`/`DownloadFileError`, повтор на свежей сессии, ограничение длины сообщения. `tests/test_client_ssl.py` расширен под новый контракт владения.

Проверено, что тесты не декоративные: при откате фикса падает 18 из 22.

`make run-test` — **986 passed, 12 skipped**, ruff + ruff format + mypy чисто.

🤖 Generated with [Claude Code](https://claude.com/claude-code)