### PR TITLE
fix: change_info(commands=[]) очищает команды вместо ValueError

### DIFF
--- a/maxapi/methods/change_info.py
+++ b/maxapi/methods/change_info.py
@@ -27,7 +27,7 @@ class ChangeInfo(BaseConnection):
         last_name: Второе имя бота (1–64 символа).
         description: Описание бота (1–16000 символов).
         commands: Список команд
-            (до 32 элементов).
+            (до 32 элементов). Пустой список удаляет все команды.
         photo: Фото бота.
 
     Note:
@@ -52,7 +52,8 @@ class ChangeInfo(BaseConnection):
             stacklevel=2,
         )
 
-        if not any([first_name, last_name, description, commands, photo]):
+        params = (first_name, last_name, description, commands, photo)
+        if all(param is None for param in params):
             raise ValueError(
                 "Нужно указать хотя бы один параметр для изменения"
             )
@@ -95,7 +96,7 @@ class ChangeInfo(BaseConnection):
             json["last_name"] = self.last_name
         if self.description:
             json["description"] = self.description
-        if self.commands:
+        if self.commands is not None:
             json["commands"] = [
                 command.model_dump() for command in self.commands
             ]

--- a/tests/test_set_commands.py
+++ b/tests/test_set_commands.py
@@ -6,6 +6,7 @@ import pytest
 from maxapi.connection.base import BaseConnection
 from maxapi.enums.api_path import ApiPath
 from maxapi.enums.http_method import HTTPMethod
+from maxapi.methods.change_info import ChangeInfo
 from maxapi.methods.set_commands import SetCommands
 from maxapi.methods.types.setted_commands import SettedCommands
 from maxapi.types.command import BotCommand
@@ -99,3 +100,40 @@ async def test_bot_set_my_commands_is_deprecated(bot):
         await bot.set_my_commands(BotCommand(name="/start"))
 
     assert mocked_request.call_args.kwargs["path"] == ApiPath.ME
+
+
+async def test_change_info_empty_commands_clears_them(bot):
+    """Пустой список команд уходит в тело запроса, а не отбрасывается."""
+    with pytest.deprecated_call(match="ChangeInfo"):
+        method = ChangeInfo(bot=bot, commands=[])
+
+    with patch.object(
+        BaseConnection, "request", new=AsyncMock(return_value=Mock())
+    ) as mocked_request:
+        await method.fetch()
+
+    assert mocked_request.call_args.kwargs["json"] == {"commands": []}
+
+
+async def test_change_info_without_params_raises(bot):
+    """Без единого параметра запрос по-прежнему отклоняется."""
+    with (
+        pytest.deprecated_call(match="ChangeInfo"),
+        pytest.raises(ValueError, match="хотя бы один параметр"),
+    ):
+        ChangeInfo(bot=bot)
+
+
+async def test_bot_set_my_commands_without_args_clears_commands(bot):
+    """Вызов без аргументов очищает команды через PATCH /me."""
+    with (
+        patch.object(
+            BaseConnection, "request", new=AsyncMock(return_value=Mock())
+        ) as mocked_request,
+        pytest.deprecated_call(match="set_commands"),
+    ):
+        await bot.set_my_commands()
+
+    kwargs = mocked_request.call_args.kwargs
+    assert kwargs["path"] == ApiPath.ME
+    assert kwargs["json"] == {"commands": []}


### PR DESCRIPTION
## Проблема

Докстринг `Bot.change_info` обещает: «Передайте пустой список, чтобы удалить все команды». На деле:

1. guard в `ChangeInfo.__init__` проверял параметры через `any([...])`, и `commands=[]` считался отсутствующим → `ValueError("Нужно указать хотя бы один параметр")`;
2. даже минуя guard, `fetch()` собирал `commands` через truthiness и `[]` выпадал из тела запроса.

Из-за этого ломался и `await bot.set_my_commands()` без аргументов, который строит `ChangeInfo(commands=[])`.

## Исправление

- guard: `all(param is None for param in params)`;
- `fetch()`: `if self.commands is not None:` (как в `SetCommands`);
- докстринг `ChangeInfo` дополнен, deprecation-предупреждения не тронуты.

## Тесты

`ChangeInfo(commands=[])` отправляет `{"commands": []}`; без параметров по-прежнему `ValueError`; `bot.set_my_commands()` без аргументов шлёт `{"commands": []}` на `/me`.

`ruff check`, `ruff format --check`, `mypy`, pytest: 969 passed, 12 skipped.

Найдено при code review PR #210.

🤖 Generated with [Claude Code](https://claude.com/claude-code)