### PR TITLE
fix: зависание shutdown() и падение тестов остановки polling на Python 3.12+

### DIFF
--- a/maxapi/dispatcher.py
+++ b/maxapi/dispatcher.py
@@ -2376,7 +2376,16 @@ class Dispatcher(BotMixin):
             # уступает, а call_soon выполняет callback'и по порядку —
             # к пробуждению задачи убраны из пула, их ошибки
             # залогированы.
-            await asyncio.wait(pending)
+            try:
+                await asyncio.wait(pending)
+            except asyncio.CancelledError:
+                # gather() отменял бы дочерние задачи вместе с собой;
+                # wait() этого не делает — сохраняем поведение: отмена
+                # shutdown() (например, по таймауту lifespan) отменяет
+                # и недождавшиеся фоновые задачи.
+                for task in pending:
+                    task.cancel()
+                raise
             drained = True
         if drained:
             logger_dp.info("Все фоновые задачи завершены")

--- a/maxapi/dispatcher.py
+++ b/maxapi/dispatcher.py
@@ -2368,13 +2368,15 @@ class Dispatcher(BotMixin):
                 "Ожидаю завершения %d фоновых задач...",
                 len(pending),
             )
-            await asyncio.gather(*pending, return_exceptions=True)
-            # Задачу из пула удаляет её done-callback, но он мог ещё не
-            # выполниться: задача завершилась, а нас разбудили раньше.
-            # С Python 3.12 gather() по уже завершённым задачам
-            # отрабатывает синхронно и не уступает цикл событий — без
-            # явного удаления цикл while крутился бы вечно.
-            self._background_tasks.difference_update(pending)
+            # Именно wait(), а не gather(): задачу из пула удаляет её
+            # done-callback, который мог ещё не выполниться (задача
+            # завершилась, а нас разбудили раньше). С Python 3.12
+            # gather() по уже завершённым задачам не уступает цикл
+            # событий, и while крутился бы вечно. wait() всегда
+            # уступает, а call_soon выполняет callback'и по порядку —
+            # к пробуждению задачи убраны из пула, их ошибки
+            # залогированы.
+            await asyncio.wait(pending)
             drained = True
         if drained:
             logger_dp.info("Все фоновые задачи завершены")

--- a/maxapi/dispatcher.py
+++ b/maxapi/dispatcher.py
@@ -2369,6 +2369,12 @@ class Dispatcher(BotMixin):
                 len(pending),
             )
             await asyncio.gather(*pending, return_exceptions=True)
+            # Задачу из пула удаляет её done-callback, но он мог ещё не
+            # выполниться: задача завершилась, а нас разбудили раньше.
+            # С Python 3.12 gather() по уже завершённым задачам
+            # отрабатывает синхронно и не уступает цикл событий — без
+            # явного удаления цикл while крутился бы вечно.
+            self._background_tasks.difference_update(pending)
             drained = True
         if drained:
             logger_dp.info("Все фоновые задачи завершены")

--- a/maxapi/dispatcher.py
+++ b/maxapi/dispatcher.py
@@ -2385,6 +2385,10 @@ class Dispatcher(BotMixin):
                 # и недождавшиеся фоновые задачи.
                 for task in pending:
                     task.cancel()
+                # cancel() лишь запрашивает отмену: как и gather(),
+                # дожидаемся, пока задачи доработают cleanup и уйдут
+                # из пула, и только потом пробрасываем отмену.
+                await asyncio.wait(pending)
                 raise
             drained = True
         if drained:

--- a/tests/test_dispatcher_stop_polling.py
+++ b/tests/test_dispatcher_stop_polling.py
@@ -47,6 +47,16 @@ async def _let_tasks_run(iterations: int = 5) -> None:
         await asyncio.sleep(0)
 
 
+async def _await_background(dispatcher: Dispatcher) -> None:
+    """Дожидается фоновых задач вместе с их done-callback'ами.
+
+    ``asyncio.wait`` всегда уступает цикл событий, поэтому к возврату
+    задачи уже убраны из пула (см. дренаж в ``Dispatcher.shutdown``).
+    """
+    if pending := tuple(dispatcher._background_tasks):
+        await asyncio.wait_for(asyncio.wait(pending), STOP_TIMEOUT)
+
+
 def _reentrancy_warnings(caplog) -> list[str]:
     """Предупреждения shutdown о вызове из обработчика."""
     return [
@@ -354,35 +364,35 @@ class TestStopPollingSafety:
 
             # Сам обработчик доживает в фоне: он дожидался цикла polling,
             # а не наоборот (иначе задача ждала бы саму себя).
-            await asyncio.wait_for(
-                asyncio.gather(*dispatcher._background_tasks), STOP_TIMEOUT
-            )
-            # Из пула задачу удаляет её done-callback — даём ему
-            # выполниться (с 3.12 gather() по завершённым задачам не
-            # уступает цикл событий).
-            await _let_tasks_run()
+            await _await_background(dispatcher)
 
         assert handled == [fixture_message_created]
         assert dispatcher._background_tasks == set()
 
+    @pytest.mark.parametrize("failing", [False, True], ids=["ok", "error"])
     async def test_shutdown_drains_finished_task_before_its_callback(
-        self,
+        self, caplog, failing
     ):
         """shutdown не зацикливается на завершённой, но не убранной задаче.
 
-        Обработчик будит вызывающего событием и завершается; тот
-        вызывает ``shutdown()`` раньше, чем done-callback задачи успел
-        удалить её из пула. С Python 3.12 ``gather()`` по уже
-        завершённым задачам не уступает цикл событий — без явного
-        удаления из пула дренаж крутился бы вечно.
+        Задача будит вызывающего событием и завершается; тот вызывает
+        ``shutdown()`` раньше, чем done-callback задачи успел удалить её
+        из пула (см. дренаж в ``Dispatcher.shutdown``). К возврату из
+        ``shutdown()`` callback уже отработал: задача убрана из пула, а
+        её ошибка залогирована. Задача регистрируется в пуле напрямую:
+        ``spawn_handle_task`` без запущенного диспетчера обработчик не
+        найдёт, а ``handle()`` сам перехватывает исключения.
         """
         dispatcher = Dispatcher(use_create_task=True)
         released = asyncio.Event()
 
-        async def _handler():
+        async def _task():
             released.set()
+            if failing:
+                msg = "упал"
+                raise RuntimeError(msg)
 
-        task = asyncio.create_task(_handler())
+        task = asyncio.create_task(_task())
         dispatcher._background_tasks.add(task)
         task.add_done_callback(dispatcher._on_background_task_done)
 
@@ -393,6 +403,11 @@ class TestStopPollingSafety:
         await asyncio.wait_for(dispatcher.shutdown(), STOP_TIMEOUT)
 
         assert dispatcher._background_tasks == set()
+        logged = any(
+            "Необработанное исключение в фоновой задаче" in r.getMessage()
+            for r in caplog.records
+        )
+        assert logged is failing
 
     async def test_stop_does_not_wait_for_caller_task(
         self, polling_bot, fixture_message_created
@@ -471,9 +486,7 @@ class TestStopPollingSafety:
             task = asyncio.create_task(dispatcher.start_polling(polling_bot))
             await asyncio.wait_for(task, STOP_TIMEOUT)
 
-            await asyncio.wait_for(
-                asyncio.gather(*dispatcher._background_tasks), STOP_TIMEOUT
-            )
+            await _await_background(dispatcher)
 
         # Изоляция не сломана: второй обработчик дождался первого.
         assert handled == ["первый", "второй"]
@@ -1096,9 +1109,7 @@ class TestReentrantShutdown:
             await asyncio.wait_for(task, STOP_TIMEOUT)
 
             release.set()
-            await asyncio.wait_for(
-                asyncio.gather(*dispatcher._background_tasks), STOP_TIMEOUT
-            )
+            await _await_background(dispatcher)
 
         assert handled == ["первый", "второй-остановил", "первый-продолжил"]
 
@@ -1134,9 +1145,7 @@ class TestReentrantShutdown:
         ):
             task = asyncio.create_task(dispatcher.start_polling(polling_bot))
             await asyncio.wait_for(task, STOP_TIMEOUT)
-            await asyncio.wait_for(
-                asyncio.gather(*dispatcher._background_tasks), STOP_TIMEOUT
-            )
+            await _await_background(dispatcher)
 
         assert handled == ["обработан"]
         assert _reentrancy_warnings(caplog) == []

--- a/tests/test_dispatcher_stop_polling.py
+++ b/tests/test_dispatcher_stop_polling.py
@@ -54,7 +54,10 @@ async def _await_background(dispatcher: Dispatcher) -> None:
     задачи уже убраны из пула (см. дренаж в ``Dispatcher.shutdown``).
     """
     if pending := tuple(dispatcher._background_tasks):
-        await asyncio.wait_for(asyncio.wait(pending), STOP_TIMEOUT)
+        done, _ = await asyncio.wait_for(asyncio.wait(pending), STOP_TIMEOUT)
+        for task in done:
+            if not task.cancelled() and (exc := task.exception()) is not None:
+                raise exc
 
 
 def _reentrancy_warnings(caplog) -> list[str]:
@@ -371,7 +374,7 @@ class TestStopPollingSafety:
 
     @pytest.mark.parametrize("failing", [False, True], ids=["ok", "error"])
     async def test_shutdown_drains_finished_task_before_its_callback(
-        self, caplog, failing
+        self, dispatcher, caplog, failing
     ):
         """shutdown не зацикливается на завершённой, но не убранной задаче.
 
@@ -383,7 +386,6 @@ class TestStopPollingSafety:
         ``spawn_handle_task`` без запущенного диспетчера обработчик не
         найдёт, а ``handle()`` сам перехватывает исключения.
         """
-        dispatcher = Dispatcher(use_create_task=True)
         released = asyncio.Event()
 
         async def _task():
@@ -408,6 +410,41 @@ class TestStopPollingSafety:
             for r in caplog.records
         )
         assert logged is failing
+
+    async def test_cancelled_shutdown_cancels_pending_tasks(self, dispatcher):
+        """Отмена shutdown() посреди дренажа отменяет и фоновые задачи.
+
+        Так вёл себя gather(); с переходом на wait() поведение
+        сохранено явно: обработчик не должен пережить отменённую
+        (например, по таймауту lifespan) остановку.
+        """
+        started = asyncio.Event()
+        cancelled = asyncio.Event()
+
+        async def _hanging():
+            started.set()
+            try:
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                cancelled.set()
+                raise
+
+        task = asyncio.create_task(_hanging())
+        dispatcher._background_tasks.add(task)
+        task.add_done_callback(dispatcher._on_background_task_done)
+        await started.wait()
+
+        shutdown = asyncio.create_task(dispatcher.shutdown())
+        await _let_tasks_run()
+        assert not shutdown.done()
+
+        shutdown.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await asyncio.wait_for(shutdown, STOP_TIMEOUT)
+
+        await asyncio.wait_for(cancelled.wait(), STOP_TIMEOUT)
+        await _await_background(dispatcher)
+        assert dispatcher._background_tasks == set()
 
     async def test_stop_does_not_wait_for_caller_task(
         self, polling_bot, fixture_message_created
@@ -443,9 +480,8 @@ class TestStopPollingSafety:
             new=AsyncMock(return_value=[fixture_message_created]),
         ):
             await asyncio.wait_for(_main(), STOP_TIMEOUT)
-            # Обработчик будит ``_main`` раньше, чем завершается сам:
-            # даём его done-callback убрать задачу из пула.
-            await _let_tasks_run()
+            # Обработчик будит ``_main`` раньше, чем завершается сам.
+            await _await_background(dispatcher)
 
         assert order == ["цикл завершён", "остановлен", "продолжение"]
         assert dispatcher._background_tasks == set()
@@ -1053,10 +1089,7 @@ class TestReentrantShutdown:
         assert "(1)" in warnings[0]
 
         # Пропущенная задача доработает сама.
-        await asyncio.wait_for(
-            asyncio.gather(*tuple(dispatcher._background_tasks)),
-            STOP_TIMEOUT,
-        )
+        await _await_background(dispatcher)
 
         assert handled == ["вебхук", "фоновый"]
 

--- a/tests/test_dispatcher_stop_polling.py
+++ b/tests/test_dispatcher_stop_polling.py
@@ -447,8 +447,9 @@ class TestStopPollingSafety:
         with pytest.raises(asyncio.CancelledError):
             await asyncio.wait_for(shutdown, STOP_TIMEOUT)
 
-        await asyncio.wait_for(cancelled.wait(), STOP_TIMEOUT)
-        await _await_background(dispatcher)
+        # Как и с gather(): к моменту отмены shutdown() обработчик уже
+        # доработал cleanup и убран из пула.
+        assert cancelled.is_set()
         assert dispatcher._background_tasks == set()
 
     async def test_stop_does_not_wait_for_caller_task(

--- a/tests/test_dispatcher_stop_polling.py
+++ b/tests/test_dispatcher_stop_polling.py
@@ -357,8 +357,41 @@ class TestStopPollingSafety:
             await asyncio.wait_for(
                 asyncio.gather(*dispatcher._background_tasks), STOP_TIMEOUT
             )
+            # Из пула задачу удаляет её done-callback — даём ему
+            # выполниться (с 3.12 gather() по завершённым задачам не
+            # уступает цикл событий).
+            await _let_tasks_run()
 
         assert handled == [fixture_message_created]
+        assert dispatcher._background_tasks == set()
+
+    async def test_shutdown_drains_finished_task_before_its_callback(
+        self,
+    ):
+        """shutdown не зацикливается на завершённой, но не убранной задаче.
+
+        Обработчик будит вызывающего событием и завершается; тот
+        вызывает ``shutdown()`` раньше, чем done-callback задачи успел
+        удалить её из пула. С Python 3.12 ``gather()`` по уже
+        завершённым задачам не уступает цикл событий — без явного
+        удаления из пула дренаж крутился бы вечно.
+        """
+        dispatcher = Dispatcher(use_create_task=True)
+        released = asyncio.Event()
+
+        async def _handler():
+            released.set()
+
+        task = asyncio.create_task(_handler())
+        dispatcher._background_tasks.add(task)
+        task.add_done_callback(dispatcher._on_background_task_done)
+
+        await released.wait()
+        assert task.done()
+        assert task in dispatcher._background_tasks
+
+        await asyncio.wait_for(dispatcher.shutdown(), STOP_TIMEOUT)
+
         assert dispatcher._background_tasks == set()
 
     async def test_stop_does_not_wait_for_caller_task(
@@ -395,6 +428,9 @@ class TestStopPollingSafety:
             new=AsyncMock(return_value=[fixture_message_created]),
         ):
             await asyncio.wait_for(_main(), STOP_TIMEOUT)
+            # Обработчик будит ``_main`` раньше, чем завершается сам:
+            # даём его done-callback убрать задачу из пула.
+            await _let_tasks_run()
 
         assert order == ["цикл завершён", "остановлен", "продолжение"]
         assert dispatcher._background_tasks == set()
@@ -617,6 +653,7 @@ class TestStopPollingSafety:
         entered = asyncio.Event()
         release = asyncio.Event()
         restarted = asyncio.Event()
+        first_done = asyncio.Event()
         order: list[str] = []
 
         @dispatcher.message_created()
@@ -627,6 +664,7 @@ class TestStopPollingSafety:
         async def _restarter():
             await dispatcher.start_polling(polling_bot)
             order.append("первый цикл завершён")
+            first_done.set()
             polling_bot.get_updates = _hanging_updates(restarted, [])
             await dispatcher.start_polling(polling_bot)
 
@@ -645,6 +683,10 @@ class TestStopPollingSafety:
             stopper = asyncio.create_task(_stopper())
 
             await asyncio.wait_for(entered.wait(), STOP_TIMEOUT)
+            # Число оборотов цикла до выхода A из start_polling зависит
+            # от версии asyncio — ждём сам факт, а не фиксированное
+            # число итераций.
+            await asyncio.wait_for(first_done.wait(), STOP_TIMEOUT)
             await _let_tasks_run()
 
             # Цикл вышел, A уже вернулась из первого start_polling, но

--- a/tests/test_dispatcher_stop_polling.py
+++ b/tests/test_dispatcher_stop_polling.py
@@ -402,7 +402,12 @@ class TestStopPollingSafety:
         assert task.done()
         assert task in dispatcher._background_tasks
 
-        await asyncio.wait_for(dispatcher.shutdown(), STOP_TIMEOUT)
+        # Без wait_for: до Python 3.12 он оборачивал бы shutdown() в
+        # отдельную задачу, и done-callback успел бы убрать задачу из
+        # пула ещё до начала дренажа — гонка не воспроизвелась бы.
+        # От зависания тест это всё равно не защищало: busy-loop не
+        # уступает цикл событий, и таймаут не сработал бы.
+        await dispatcher.shutdown()
 
         assert dispatcher._background_tasks == set()
         logged = any(


### PR DESCRIPTION
## Проблема

После вливания #222 пайплайн `Tests` падает на Python 3.12+ ([run 34520679552](https://github.com/love-apples/maxapi/actions/runs/34520679552)): три теста в `tests/test_dispatcher_stop_polling.py`, на 3.10/3.11 всё зелёное.

Причина не в тестах, а в изменении asyncio в 3.12: `asyncio.gather()` по уже завершённым задачам отрабатывает синхронно и не уступает цикл событий, а `wait_for()` больше не оборачивает корутину в отдельную задачу. Тесты опирались на число «оборотов» цикла, которое изменилось.

При этом тесты вскрыли реальный баг библиотеки. Дренаж в `Dispatcher.shutdown()` крутил `while pending := tuple(self._background_tasks): await gather(*pending)`. Задача удаляется из пула своим done-callback, и если она уже завершилась, а callback ещё не выполнился (обработчик разбудил вызывающего событием и только потом завершился), на 3.12+ `gather` возвращается мгновенно, пул не пустеет и цикл крутится вечно, не отдавая управление. Даже `wait_for` не может его отменить.

## Изменения

- **`Dispatcher.shutdown()`**: дренаж через `asyncio.wait(pending)` вместо `gather`. `wait` всегда уступает цикл событий, а `call_soon` выполняет callback'и по порядку, поэтому к пробуждению задачи уже убраны из пула и их ошибки залогированы. Каскадная отмена, которую давал `gather`, сохранена явно: отмена `shutdown()` посреди дренажа (например, по таймауту lifespan) отменяет и недождавшиеся фоновые задачи.
- **Тесты остановки polling**: ожидания фиксированного числа итераций заменены на события и хелпер `_await_background`, который дожидается пула вместе с done-callback'ами и пробрасывает исключения задач.
- **Новые регрессионные тесты**: `shutdown()` не зацикливается на завершённой, но ещё не убранной из пула задаче (варианты с успешной и упавшей задачей, лог ошибки есть к возврату); отмена `shutdown()` отменяет фоновые задачи.

## Проверка

- Полный набор тестов на 3.12: 1229 passed.
- `tests/test_dispatcher_stop_polling.py` на 3.10, 3.12, 3.14.
- ruff, mypy через pre-commit.
- Без правки дренажа новые тесты зависают либо падают.


## Как проскочило мимо CI в #222

До #226 матрица Python была фиктивной: закоммиченный `.python-version` (3.10) перебивал `setup-python`, и все ноги матрицы гоняли тесты на 3.10. В логе зелёной джобы `test (3.12, highest)` на PR #222 стоит `Using CPython 3.10.21`. Баг проявляется только на 3.12+, поэтому на PR его физически нельзя было увидеть.

| Событие | Время (UTC) |
|---|---|
| CI на PR #222: слияние с main до #226, все ноги на Python 3.10, зелёный | до слияния |
| #226 влит в main, матрица починена | 19:27 |
| #222 влит в main; CI на push впервые реально запустил 3.12–3.14 | 19:29 |

CI на PR #222 после вливания #226 не перезапускался, поэтому первый честный прогон на 3.12+ случился уже на main. Версии зависимостей в обоих прогонах совпадают (pytest 9.1.1, pytest-asyncio 1.4.0). Баг существовал и раньше, починка матрицы его вскрыла, а не создала.
